### PR TITLE
fix(cache,sse): Eio.Mutex in cache + real SSE streaming

### DIFF
--- a/lib/kirin.ml
+++ b/lib/kirin.ml
@@ -384,8 +384,11 @@ let sse_with_retry = Sse.with_retry
 (** Encode SSE event to string *)
 let sse_encode = Sse.encode
 
-(** Create SSE response with events *)
-let sse_response = Sse.response
+(** Create SSE response from a list of events (convenience) *)
+let sse_response = Sse.response_legacy
+
+(** Create SSE response from an Eio.Stream of events (real streaming) *)
+let sse_stream_response = Sse.response
 
 (** SSE endpoint handler *)
 let sse_handler = Sse.handler


### PR DESCRIPTION
## Summary
- Replace `Stdlib.Mutex` with `Eio.Mutex` in `cache.ml` to prevent Eio domain blocking
- Implement `sse.ml` `response` function with Producer-based streaming (was returning empty body)
- Add `response_legacy` for backward-compatible list-based SSE responses
- Expose `sse_stream_response` in `kirin.ml` for real streaming endpoints

## Test plan
- [ ] `dune build` passes (including test_kirin.ml backward compat)
- [ ] SSE streaming verified via dashboard `/api/chat/stream` endpoint
- [ ] Cache operations tested under concurrent Eio fiber access

🤖 Generated with [Claude Code](https://claude.com/claude-code)