### PR TITLE
Hardening: Fs_compat mkdir_p without shell

### DIFF
--- a/lib/qwik/ssr.ml
+++ b/lib/qwik/ssr.ml
@@ -225,8 +225,6 @@ let prerender engine ~routes ~output_dir =
     | Ok html ->
       let path = if url = "/" then "/index" else url in
       let file_path = Filename.concat output_dir (path ^ ".html") in
-      let dir = Filename.dirname file_path in
-      ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir));
       Kirin.Fs_compat.save file_path html
     | Error msg ->
       Printf.eprintf "Failed to prerender %s: %s\n" url msg

--- a/test/dune
+++ b/test/dune
@@ -93,3 +93,7 @@
 (test
  (name test_streaming)
  (libraries kirin alcotest eio_main))
+
+(test
+ (name test_fs_compat)
+ (libraries kirin alcotest unix))

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -1,0 +1,35 @@
+(** Fs_compat tests *)
+
+open Kirin
+
+let test_save_creates_parent_dirs =
+  "save creates parent dirs", `Quick, (fun () ->
+    Random.self_init ();
+
+    let root =
+      Filename.concat
+        (Filename.get_temp_dir_name ())
+        (Printf.sprintf "kirin_fs_compat_%d_%d" (Unix.getpid ()) (Random.bits ()))
+    in
+    Unix.mkdir root 0o700;
+
+    let file_path = Filename.concat root "a/b/c.txt" in
+
+    Fun.protect
+      ~finally:(fun () ->
+        (* Best-effort cleanup in reverse order. *)
+        (try Sys.remove file_path with _ -> ());
+        (try Unix.rmdir (Filename.concat root "a/b") with _ -> ());
+        (try Unix.rmdir (Filename.concat root "a") with _ -> ());
+        (try Unix.rmdir root with _ -> ()))
+      (fun () ->
+        Fs_compat.save file_path "hello";
+        Alcotest.(check bool) "file exists" true (Sys.file_exists file_path);
+        Alcotest.(check string) "content" "hello" (Fs_compat.load file_path))
+  )
+
+let () =
+  Alcotest.run "Fs_compat" [
+    ("save", [test_save_creates_parent_dirs]);
+  ]
+


### PR DESCRIPTION
Ensures Fs_compat.save creates parent directories without shelling out; removes mkdir -p usage from Qwik prerender path and adds regression tests.