### PR TITLE
Hardening: spawn React Node SSR worker without shell

### DIFF
--- a/lib/react/node_worker.ml
+++ b/lib/react/node_worker.ml
@@ -5,8 +5,36 @@
 *)
 
 (** Node.js worker state *)
+type process = {
+  pid: int;
+  in_ch: in_channel;
+  out_ch: out_channel;
+}
+
+let reap_pid pid =
+  (* Avoid leaving zombies, but don't hang request path forever. *)
+  let wait_for ~timeout_s =
+    let deadline = Unix.gettimeofday () +. timeout_s in
+    let rec loop () =
+      match Unix.waitpid [ Unix.WNOHANG ] pid with
+      | 0, _status ->
+          if Unix.gettimeofday () >= deadline then false
+          else (
+            Unix.sleepf 0.05;
+            loop ())
+      | _pid, _status -> true
+    in
+    try loop () with
+    | Unix.Unix_error (Unix.ECHILD, _, _) -> true
+  in
+  if not (wait_for ~timeout_s:0.5) then (
+    (try Unix.kill pid Sys.sigterm with _ -> ());
+    ignore (wait_for ~timeout_s:0.5);
+    (try Unix.kill pid Sys.sigkill with _ -> ());
+    (try ignore (Unix.waitpid [] pid) with _ -> ()))
+
 type t = {
-  mutable process: (in_channel * out_channel) option;
+  mutable process: process option;
   config: Worker.config;
   mutable stats: Worker.stats;
   mutable status: Worker.status;
@@ -18,21 +46,52 @@ type t = {
 
 (** Start Node.js process *)
 let start_process config =
-  (* Build command with env vars prepended *)
-  let env_prefix =
-    config.Worker.env
-    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k v)
-    |> String.concat " "
-  in
-  let cmd =
-    if env_prefix = "" then
-      Printf.sprintf "NODE_ENV=production node %s" config.Worker.bundle_path
-    else
-      Printf.sprintf "%s NODE_ENV=production node %s" env_prefix config.Worker.bundle_path
-  in
   try
-    let (in_ch, out_ch) = Unix.open_process cmd in
-    Some (in_ch, out_ch)
+    let env_tbl : (string, string) Hashtbl.t = Hashtbl.create 64 in
+    Array.iter
+      (fun kv ->
+        match String.index_opt kv '=' with
+        | None -> ()
+        | Some i ->
+            let k = String.sub kv 0 i in
+            let v = String.sub kv (i + 1) (String.length kv - i - 1) in
+            Hashtbl.replace env_tbl k v)
+      (Unix.environment ());
+    List.iter (fun (k, v) -> Hashtbl.replace env_tbl k v) config.Worker.env;
+    Hashtbl.replace env_tbl "NODE_ENV" "production";
+    let env =
+      Hashtbl.fold (fun k v acc -> (k ^ "=" ^ v) :: acc) env_tbl [] |> Array.of_list
+    in
+
+    (* No shell: argv-only spawn prevents injection via bundle_path/env values. *)
+    let (stdin_r, stdin_w) = Unix.pipe () in
+    let (stdout_r, stdout_w) = Unix.pipe () in
+    Unix.set_close_on_exec stdin_w;
+    Unix.set_close_on_exec stdout_r;
+    let close_noerr fd = try Unix.close fd with _ -> () in
+    try
+      let pid =
+        Unix.create_process_env
+          "node"
+          [| "node"; config.Worker.bundle_path |]
+          env
+          stdin_r
+          stdout_w
+          Unix.stderr
+      in
+      (* Parent never uses these ends. *)
+      close_noerr stdin_r;
+      close_noerr stdout_w;
+      let in_ch = Unix.in_channel_of_descr stdout_r in
+      let out_ch = Unix.out_channel_of_descr stdin_w in
+      Some { pid; in_ch; out_ch }
+    with
+    | e ->
+      close_noerr stdin_r;
+      close_noerr stdin_w;
+      close_noerr stdout_r;
+      close_noerr stdout_w;
+      raise e
   with Unix.Unix_error (err, _, _) ->
     Printf.eprintf "Failed to start Node.js: %s\n%!" (Unix.error_message err);
     None
@@ -61,14 +120,14 @@ let create ?(on_event = Worker.null_handler) config =
 let send_request worker req =
   match worker.process with
   | None -> Result.Error "Worker not running"
-  | Some (in_ch, out_ch) ->
+  | Some proc ->
     try
       let request_str = Protocol.encode_request req in
-      output_string out_ch request_str;
-      output_char out_ch '\n';
-      flush out_ch;
+      output_string proc.out_ch request_str;
+      output_char proc.out_ch '\n';
+      flush proc.out_ch;
 
-      let response_str = input_line in_ch in
+      let response_str = input_line proc.in_ch in
       Protocol.decode_response response_str
     with
     | End_of_file -> Result.Error "Worker process terminated"
@@ -124,11 +183,19 @@ let restart worker =
 
   (* Close existing process *)
   (match worker.process with
-  | Some (in_ch, out_ch) ->
+  | Some proc ->
     (try
-      close_in_noerr in_ch;
-      close_out_noerr out_ch;
+      let id = Protocol.next_id () in
+      let req = Protocol.shutdown_request ~id in
+      let _ = send_request worker req in
+      ()
+    with _ -> ());
+    (try
+      close_in_noerr proc.in_ch;
+      close_out_noerr proc.out_ch;
     with _ -> ())
+    ;
+    reap_pid proc.pid
   | None -> ());
 
   (* Reset counters *)
@@ -167,7 +234,7 @@ let close worker =
   worker.on_event Worker.Stopped;
   worker.status <- Worker.Dead;
   match worker.process with
-  | Some (in_ch, out_ch) ->
+  | Some proc ->
     (try
       (* Send shutdown request *)
       let id = Protocol.next_id () in
@@ -175,8 +242,9 @@ let close worker =
       let _ = send_request worker req in
       ()
     with _ -> ());
-    close_in_noerr in_ch;
-    close_out_noerr out_ch;
+    close_in_noerr proc.in_ch;
+    close_out_noerr proc.out_ch;
+    reap_pid proc.pid;
     worker.process <- None
   | None -> ()
 

--- a/test/dune
+++ b/test/dune
@@ -97,3 +97,8 @@
 (test
  (name test_fs_compat)
  (libraries kirin alcotest unix))
+
+(test
+ (name test_no_shell_node_worker)
+ (deps ../lib/react/node_worker.ml)
+ (action (run %{exe:test_no_shell_node_worker.exe} %{dep:../lib/react/node_worker.ml})))

--- a/test/test_no_shell_node_worker.ml
+++ b/test/test_no_shell_node_worker.ml
@@ -1,0 +1,30 @@
+let string_contains hay needle =
+  let hlen = String.length hay in
+  let nlen = String.length needle in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub hay i nlen = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let () =
+  if Array.length Sys.argv <> 2 then (
+    prerr_endline "usage: test_no_shell_node_worker <path-to-node_worker.ml>";
+    exit 2
+  );
+
+  let src_path = Sys.argv.(1) in
+  let src = In_channel.(with_open_text src_path input_all) in
+
+  (* Forbid shell-based popen usage (uses /bin/sh -c). *)
+  let forbidden = [ "Unix.open_process "; "open_process_in"; "Unix.open_process_in" ] in
+  match List.find_opt (fun needle -> string_contains src needle) forbidden with
+  | None -> ()
+  | Some needle ->
+      Printf.eprintf "forbidden shell-based API found in node_worker.ml: %s\n" needle;
+      exit 1
+


### PR DESCRIPTION
Replaces Unix.open_process string command with argv-only Unix.create_process_env + explicit env handling to prevent injection. Adds regression test to forbid shell popen APIs in node_worker.