### PR TITLE
ci: make benchmark non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
     needs: build
     # Best-effort only: avoid flaking PRs on transient opam download errors.
     if: github.event_name != 'pull_request'
+    # Keep the CI signal green on main even if upstream opam downloads flake.
+    continue-on-error: true
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
Benchmark job is best-effort but was failing CI on main due to transient opam download 5xx (e.g. faraday/zarith tarballs).

This marks the benchmark job as continue-on-error so performance checks stay visible without blocking merges.