### PR TITLE
fix: strip leading slash from static relative paths

### DIFF
--- a/lib/static.ml
+++ b/lib/static.ml
@@ -12,6 +12,10 @@ let mime_of_ext ext =
   | ".gif" -> "image/gif"
   | ".svg" -> "image/svg+xml"
   | ".txt" -> "text/plain; charset=utf-8"
+  | ".woff" | ".woff2" -> "font/woff2"
+  | ".ttf" -> "font/ttf"
+  | ".eot" -> "application/vnd.ms-fontobject"
+  | ".webp" -> "image/webp"
   | _ -> "application/octet-stream"
 
 let get_mime_type path =
@@ -33,6 +37,14 @@ let static prefix ~dir =
        String.sub path 0 (String.length prefix) = prefix then
       let relative_path = 
         String.sub path (String.length prefix) (String.length path - String.length prefix)
+      in
+      
+      (* Remove leading slash to prevent Filename.concat treating it as absolute *)
+      let relative_path = 
+        if String.length relative_path > 0 && relative_path.[0] = '/' then
+          String.sub relative_path 1 (String.length relative_path - 1)
+        else
+          relative_path
       in
       
       if contains_dot_dot relative_path then


### PR DESCRIPTION
## Problem
Static files served via `Kirin.static "/static" ~dir:"/app/static"` return 404 even though files exist.

## Root Cause
`Filename.concat` treats paths starting with `/` as absolute. When:
- prefix = `"/static"`
- path = `"/static/css/styles.css"`

After substring extraction:
```ocaml
relative_path = "/css/styles.css"  (* leading slash! *)
file_path = Filename.concat "/app/static" "/css/styles.css"
          = "/css/styles.css"  (* absolute path wins, dir ignored *)
```

Result: file lookup fails.

## Solution
Strip leading `/` from `relative_path` before `Filename.concat`:
```ocaml
let relative_path = 
  if String.length relative_path > 0 && relative_path.[0] = '/' then
    String.sub relative_path 1 (String.length relative_path - 1)
  else
    relative_path
in
```

Now: `Filename.concat "/app/static" "css/styles.css"` = `"/app/static/css/styles.css"` ✓

## Additional Changes
- Added MIME types: `.woff2`, `.ttf`, `.eot`, `.webp`

## Test Plan
Tested in wkbl project. After this fix + cache bump:
- `https://wkbl.win/static/css/tailwind.css` should return HTTP 200

Generated with Claude Code