### PR TITLE
fix: remove public_name from examples to fix package build

### DIFF
--- a/examples/agent_hub/dune
+++ b/examples/agent_hub/dune
@@ -1,4 +1,3 @@
 (executable
  (name main)
- (public_name agent_hub)
  (libraries kirin yojson uuidm digestif unix))

--- a/examples/hello_world/dune
+++ b/examples/hello_world/dune
@@ -1,4 +1,3 @@
 (executable
  (name main)
- (public_name kirin_hello)
  (libraries kirin))


### PR DESCRIPTION
## Summary
- `examples/agent_hub/dune`과 `examples/hello_world/dune`에서 `(public_name ...)` 제거
- `public_name`이 있으면 `dune build -p kirin`에 포함되어 `uuidm` 등 미선언 의존성으로 CI 실패
- 제거 후에도 `dune build --root . examples/*/main.exe`로 로컬 빌드 정상 동작

## Root cause
`(public_name ...)` stanza makes dune treat the executable as part of the `kirin` package install target. Since `uuidm` (used by `agent_hub`) is not in `kirin.opam` deps, `dune build -p kirin @install` fails with a missing library error.

## Changes
- `examples/agent_hub/dune`: removed `(public_name agent_hub)`
- `examples/hello_world/dune`: removed `(public_name kirin_hello)`

## Test plan
- [x] `dune build -p kirin` succeeds (no uuidm error)
- [x] `dune build --root . examples/agent_hub/main.exe examples/hello_world/main.exe` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)