### PR TITLE
ci: fix benchmark job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
     if: github.event_name != 'pull_request'
     # Keep the CI signal green on main even if upstream opam downloads flake.
     continue-on-error: true
+    timeout-minutes: 15
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Benchmark job lacked explicit `timeout-minutes`, defaulting to GitHub's 360-minute (6 hour) limit
- If opam downloads or the benchmark itself hangs, the run shows no conclusion for hours
- Added `timeout-minutes: 15` to cap execution time (benchmark completes in ~4 min normally)

## Context
- PR #5 already made the benchmark non-blocking (`continue-on-error: true`)
- This adds the missing timeout guard to prevent indefinite hanging
- The `--quick` flag passed to the benchmark is currently ignored by the code, but the 10k-sample run still finishes in ~4 minutes, so 15 minutes provides ample headroom

## Test plan
- [ ] CI passes on this PR branch (lint + build matrix)
- [ ] Benchmark job on next main push completes within 15 minutes or is cleanly cancelled

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>