### PR TITLE
ci: add bisect_ppx coverage instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Thumbs.db
 
 # Logs
 *.log
+_coverage/

--- a/dune-project
+++ b/dune-project
@@ -61,6 +61,7 @@ Features:
   (ocaml-webrtc (>= "0.1.0"))
   (graphql (>= "0.14.0"))
   (graphql_parser (>= "0.14.0"))
+  (bisect_ppx (and (>= 2.8) :with-dev-setup))
   (alcotest :with-test)
   (odoc :with-doc))
  (tags

--- a/kirin.opam
+++ b/kirin.opam
@@ -60,6 +60,7 @@ depends: [
   "ocaml-webrtc" {>= "0.1.0"}
   "graphql" {>= "0.14.0"}
   "graphql_parser" {>= "0.14.0"}
+  "bisect_ppx" {>= "2.8" & with-dev-setup}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]

--- a/lib/alpine/dune
+++ b/lib/alpine/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_alpine)
  (public_name kirin.alpine)
- (libraries kirin yojson str unix))
+ (libraries kirin yojson str unix)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/angular/dune
+++ b/lib/angular/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_angular)
  (public_name kirin.angular)
- (libraries kirin yojson str))
+ (libraries kirin yojson str)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/astro/dune
+++ b/lib/astro/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_astro)
  (public_name kirin.astro)
- (libraries kirin yojson str unix))
+ (libraries kirin yojson str unix)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/auth/dune
+++ b/lib/auth/dune
@@ -8,4 +8,5 @@
   base64          ; Base64 encoding
   yojson          ; JSON handling
   uri             ; URL encoding for OAuth2
-  eio))
+  eio)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/browser/dune
+++ b/lib/browser/dune
@@ -4,4 +4,5 @@
  (optional)  ; Only build when js_of_ocaml is available
  (libraries js_of_ocaml yojson)
  (preprocess
-  (pps js_of_ocaml-ppx)))
+  (pps js_of_ocaml-ppx))
+ (instrumentation (backend bisect_ppx)))

--- a/lib/dune
+++ b/lib/dune
@@ -31,4 +31,5 @@
   str
   dune-build-info)
  (preprocess
-  (pps ppx_deriving.show ppx_deriving_yojson)))
+  (pps ppx_deriving.show ppx_deriving_yojson))
+ (instrumentation (backend bisect_ppx)))

--- a/lib/htmx/dune
+++ b/lib/htmx/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_htmx)
  (public_name kirin.htmx)
- (libraries kirin yojson))
+ (libraries kirin yojson)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/lit/dune
+++ b/lib/lit/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_lit)
  (public_name kirin.lit)
- (libraries kirin yojson str unix))
+ (libraries kirin yojson str unix)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/mcp/dune
+++ b/lib/mcp/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_mcp)
  (public_name kirin.mcp)
- (libraries yojson eio))
+ (libraries yojson eio)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/preact/dune
+++ b/lib/preact/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_preact)
  (public_name kirin.preact)
- (libraries kirin yojson str unix))
+ (libraries kirin yojson str unix)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/qwik/dune
+++ b/lib/qwik/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_qwik)
  (public_name kirin.qwik)
- (libraries kirin yojson str unix))
+ (libraries kirin yojson str unix)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/react/dune
+++ b/lib/react/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_react)
  (public_name kirin.react)
- (libraries kirin yojson eio cohttp-eio uri str unix base64))
+ (libraries kirin yojson eio cohttp-eio uri str unix base64)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/remix/dune
+++ b/lib/remix/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_remix)
  (public_name kirin.remix)
- (libraries kirin yojson str unix))
+ (libraries kirin yojson str unix)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/solid/dune
+++ b/lib/solid/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_solid)
  (public_name kirin.solid)
- (libraries kirin yojson unix str))
+ (libraries kirin yojson unix str)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/svelte/dune
+++ b/lib/svelte/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_svelte)
  (public_name kirin.svelte)
- (libraries kirin yojson unix str))
+ (libraries kirin yojson unix str)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/tanstack/dune
+++ b/lib/tanstack/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_tanstack)
  (public_name kirin.tanstack)
- (libraries kirin yojson unix str))
+ (libraries kirin yojson unix str)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/trpc/dune
+++ b/lib/trpc/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_trpc)
  (public_name kirin.trpc)
- (libraries kirin yojson uri unix))
+ (libraries kirin yojson uri unix)
+ (instrumentation (backend bisect_ppx)))

--- a/lib/vue/dune
+++ b/lib/vue/dune
@@ -1,4 +1,5 @@
 (library
  (name kirin_vue)
  (public_name kirin.vue)
- (libraries kirin yojson str unix))
+ (libraries kirin yojson str unix)
+ (instrumentation (backend bisect_ppx)))


### PR DESCRIPTION
## Summary
- `bisect_ppx (>= 2.8, :with-dev-setup)` 의존성 추가 (dune-project, kirin.opam)
- 18개 library stanza에 `(instrumentation (backend bisect_ppx))` 추가
- `_coverage/` 디렉토리 .gitignore에 추가

## Baseline
- 커버리지: **39.23%** (5932/15120 points)
- 테스트 전체 통과 확인

## 사용법
```bash
mkdir -p _coverage
BISECT_FILE=$(pwd)/_coverage/bisect dune test --root . --instrument-with bisect_ppx --force
bisect-ppx-report summary --coverage-path=_coverage
```

## Test plan
- [x] `dune build --root .` 성공
- [x] `dune test --root . --instrument-with bisect_ppx --force` 전체 통과
- [x] `bisect-ppx-report summary` 리포트 생성 확인
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)