### PR TITLE
feat(mcp): upgrade protocol to 2025-11-25 specification

### DIFF
--- a/examples/mcp_client/main.ml
+++ b/examples/mcp_client/main.ml
@@ -1,7 +1,7 @@
 (** Kirin MCP Client Example
 
-    Demonstrates how to create an MCP client that uses HTTP+SSE transport.
-    This is the typical setup for web-based MCP servers.
+    Demonstrates how to create an MCP client that uses Streamable HTTP transport.
+    This is the typical setup for web-based MCP servers (2025-11-25 spec).
 
     In a real application, you would connect to an MCP server endpoint
     and use the client to call tools, read resources, etc.
@@ -16,9 +16,9 @@ let () =
   Printf.printf "Kirin MCP Client Example\n";
   Printf.printf "========================\n\n";
 
-  (* Create HTTP+SSE transport (for web-based MCP servers) *)
-  let transport = Mcp.Transport.of_http_sse () in
-  Printf.printf "Created HTTP+SSE transport\n";
+  (* Create Streamable HTTP transport (for web-based MCP servers) *)
+  let transport = Mcp.Transport.create_streamable_http () in
+  Printf.printf "Created Streamable HTTP transport\n";
 
   (* Create client *)
   let client = Mcp.Client.create transport in
@@ -49,12 +49,13 @@ let () =
 
   Printf.printf "\nTo connect to a real MCP server:\n";
   Printf.printf "  1. Start an MCP server (e.g., run mcp_server example)\n";
-  Printf.printf "  2. The client would POST to /mcp endpoint\n";
-  Printf.printf "  3. Server-sent events come from /mcp/sse\n";
+  Printf.printf "  2. Client POSTs JSON-RPC to /mcp endpoint\n";
+  Printf.printf "  3. Server responds with JSON or SSE stream\n";
+  Printf.printf "  4. Mcp-Session-Id header tracks the session\n";
 
   (* Show transport check *)
   Printf.printf "\nTransport type: %s\n"
-    (if Mcp.Transport.is_http_sse transport then "HTTP+SSE" else "stdio");
+    (if Mcp.Transport.is_streamable_http transport then "Streamable HTTP" else "stdio");
 
   ignore client;
   Printf.printf "\nMCP client demo complete.\n"

--- a/lib/mcp/jsonrpc.ml
+++ b/lib/mcp/jsonrpc.ml
@@ -216,3 +216,12 @@ let success_response ~id result =
 
 let error_response ~id err =
   { id; result = None; error = Some err }
+
+(** Extract _meta from params if present *)
+let extract_meta params =
+  match params with
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt "_meta" fields with
+     | Some meta -> Some meta
+     | None -> None)
+  | _ -> None

--- a/lib/mcp/kirin_mcp.ml
+++ b/lib/mcp/kirin_mcp.ml
@@ -54,8 +54,11 @@ module Protocol = Protocol
 (** JSON Schema builder for tool input definitions *)
 module Schema = Schema
 
-(** Transport layer (stdio, HTTP+SSE) *)
+(** Transport layer (stdio, Streamable HTTP) *)
 module Transport = Transport
+
+(** Tasks primitive for async tool execution *)
+module Tasks = Tasks
 
 (** Session management and lifecycle *)
 module Session = Session

--- a/lib/mcp/protocol.ml
+++ b/lib/mcp/protocol.ml
@@ -1,6 +1,6 @@
 (** Kirin MCP - Protocol Types
 
-    MCP (Model Context Protocol) 2024-11 specification types.
+    MCP (Model Context Protocol) 2025-11-25 specification types.
     Defines all MCP message structures for tools, resources, and prompts.
 *)
 
@@ -10,22 +10,62 @@
 type implementation_info = {
   name : string;
   version : string;
+  description : string option;  (** Human-readable description (2025-11-25) *)
+}
+
+(** Icon metadata for tools, resources, and prompts (2025-11-25) *)
+type icon = {
+  uri : string;  (** data: URI or https: URI *)
 }
 
 (** {1 Capabilities} *)
 
+(** Tool annotations — behavioral hints for AI agents (2025-11-25) *)
+type tool_annotations = {
+  title : string option;              (** Human-readable title *)
+  read_only_hint : bool option;       (** Hint: tool only reads data (default true) *)
+  destructive_hint : bool option;     (** Hint: tool may have destructive side-effects (default true) *)
+  idempotent_hint : bool option;      (** Hint: calling repeatedly has same effect (default false) *)
+  open_world_hint : bool option;      (** Hint: tool interacts with external entities (default true) *)
+}
+
+(** Server tools capability (2025-11-25) *)
+type tools_capability = {
+  list_changed : bool option;  (** Supports notifications/tools/list_changed *)
+}
+
+(** Server resources capability (2025-11-25) *)
+type resources_capability = {
+  subscribe : bool option;     (** Supports resources/subscribe *)
+  list_changed : bool option;  (** Supports notifications/resources/list_changed *)
+}
+
+(** Server prompts capability (2025-11-25) *)
+type prompts_capability = {
+  list_changed : bool option;  (** Supports notifications/prompts/list_changed *)
+}
+
 (** Server capabilities *)
 type server_capabilities = {
-  tools : bool option;
-  resources : bool option;
-  prompts : bool option;
-  logging : bool option;
+  tools : tools_capability option;
+  resources : resources_capability option;
+  prompts : prompts_capability option;
+  logging : bool option;  (** Empty object = supported *)
 }
+
+(** Roots capability for client *)
+type roots_capability = {
+  list_changed : bool option;
+}
+
+(** Sampling capability for client *)
+type sampling_capability = unit  (** Empty object = supported *)
 
 (** Client capabilities *)
 type client_capabilities = {
-  roots : bool option;
-  sampling : bool option;
+  roots : roots_capability option;
+  sampling : sampling_capability option;
+  experimental : Yojson.Safe.t option;  (** Experimental capabilities (2025-11-25) *)
 }
 
 (** {1 Tools} *)
@@ -35,18 +75,22 @@ type tool = {
   name : string;
   description : string option;
   input_schema : Yojson.Safe.t;
+  annotations : tool_annotations option;  (** Behavioral hints (2025-11-25) *)
+  icon : icon option;                     (** Tool icon (2025-11-25) *)
 }
 
 (** Tool call request *)
 type tool_call = {
   name : string;
   arguments : Yojson.Safe.t option;
+  _meta : Yojson.Safe.t option;  (** Request metadata (2025-11-25) *)
 }
 
 (** Tool call result *)
 type tool_result = {
   content : content list;
   is_error : bool option;
+  _meta : Yojson.Safe.t option;  (** Result metadata (2025-11-25) *)
 }
 
 (** Content types *)
@@ -63,6 +107,7 @@ type resource = {
   name : string;
   description : string option;
   mime_type : string option;
+  icon : icon option;  (** Resource icon (2025-11-25) *)
 }
 
 (** Resource contents *)
@@ -87,6 +132,7 @@ type prompt = {
   name : string;
   description : string option;
   arguments : prompt_argument list option;
+  icon : icon option;  (** Prompt icon (2025-11-25) *)
 }
 
 (** Prompt message *)
@@ -102,6 +148,7 @@ type initialize_params = {
   protocol_version : string;
   capabilities : client_capabilities;
   client_info : implementation_info;
+  _meta : Yojson.Safe.t option;  (** Request metadata (2025-11-25) *)
 }
 
 (** Initialize result *)
@@ -109,29 +156,88 @@ type initialize_result = {
   protocol_version : string;
   capabilities : server_capabilities;
   server_info : implementation_info;
+  _meta : Yojson.Safe.t option;  (** Result metadata (2025-11-25) *)
 }
 
 (** {1 JSON Encoding} *)
 
 let implementation_info_to_json (info : implementation_info) =
-  `Assoc [
+  let base = [
     "name", `String info.name;
     "version", `String info.version;
-  ]
+  ] in
+  let fields = match info.description with
+    | Some d -> ("description", `String d) :: base
+    | None -> base
+  in
+  `Assoc fields
+
+let icon_to_json (i : icon) =
+  `Assoc ["uri", `String i.uri]
+
+let tool_annotations_to_json (a : tool_annotations) =
+  let fields = [] in
+  let fields = match a.title with
+    | Some t -> ("title", `String t) :: fields
+    | None -> fields
+  in
+  let fields = match a.read_only_hint with
+    | Some b -> ("readOnlyHint", `Bool b) :: fields
+    | None -> fields
+  in
+  let fields = match a.destructive_hint with
+    | Some b -> ("destructiveHint", `Bool b) :: fields
+    | None -> fields
+  in
+  let fields = match a.idempotent_hint with
+    | Some b -> ("idempotentHint", `Bool b) :: fields
+    | None -> fields
+  in
+  let fields = match a.open_world_hint with
+    | Some b -> ("openWorldHint", `Bool b) :: fields
+    | None -> fields
+  in
+  `Assoc fields
+
+let tools_capability_to_json (tc : tools_capability) =
+  let fields = match tc.list_changed with
+    | Some b -> [("listChanged", `Bool b)]
+    | None -> []
+  in
+  `Assoc fields
+
+let resources_capability_to_json (rc : resources_capability) =
+  let fields = [] in
+  let fields = match rc.subscribe with
+    | Some b -> ("subscribe", `Bool b) :: fields
+    | None -> fields
+  in
+  let fields = match rc.list_changed with
+    | Some b -> ("listChanged", `Bool b) :: fields
+    | None -> fields
+  in
+  `Assoc fields
+
+let prompts_capability_to_json (pc : prompts_capability) =
+  let fields = match pc.list_changed with
+    | Some b -> [("listChanged", `Bool b)]
+    | None -> []
+  in
+  `Assoc fields
 
 let server_capabilities_to_json (caps : server_capabilities) =
   let fields = [] in
   let fields = match caps.tools with
-    | Some true -> ("tools", `Assoc []) :: fields
-    | _ -> fields
+    | Some tc -> ("tools", tools_capability_to_json tc) :: fields
+    | None -> fields
   in
   let fields = match caps.resources with
-    | Some true -> ("resources", `Assoc []) :: fields
-    | _ -> fields
+    | Some rc -> ("resources", resources_capability_to_json rc) :: fields
+    | None -> fields
   in
   let fields = match caps.prompts with
-    | Some true -> ("prompts", `Assoc []) :: fields
-    | _ -> fields
+    | Some pc -> ("prompts", prompts_capability_to_json pc) :: fields
+    | None -> fields
   in
   let fields = match caps.logging with
     | Some true -> ("logging", `Assoc []) :: fields
@@ -139,15 +245,26 @@ let server_capabilities_to_json (caps : server_capabilities) =
   in
   `Assoc fields
 
+let roots_capability_to_json (rc : roots_capability) =
+  let fields = match rc.list_changed with
+    | Some b -> [("listChanged", `Bool b)]
+    | None -> []
+  in
+  `Assoc fields
+
 let client_capabilities_to_json (caps : client_capabilities) =
   let fields = [] in
   let fields = match caps.roots with
-    | Some true -> ("roots", `Assoc []) :: fields
-    | _ -> fields
+    | Some rc -> ("roots", roots_capability_to_json rc) :: fields
+    | None -> fields
   in
   let fields = match caps.sampling with
-    | Some true -> ("sampling", `Assoc []) :: fields
-    | _ -> fields
+    | Some () -> ("sampling", `Assoc []) :: fields
+    | None -> fields
+  in
+  let fields = match caps.experimental with
+    | Some exp -> ("experimental", exp) :: fields
+    | None -> fields
   in
   `Assoc fields
 
@@ -156,11 +273,19 @@ let tool_to_json (t : tool) =
     "name", `String t.name;
     "inputSchema", t.input_schema;
   ] in
-  let with_desc = match t.description with
+  let fields = match t.description with
     | Some d -> ("description", `String d) :: base
     | None -> base
   in
-  `Assoc with_desc
+  let fields = match t.annotations with
+    | Some a -> ("annotations", tool_annotations_to_json a) :: fields
+    | None -> fields
+  in
+  let fields = match t.icon with
+    | Some i -> ("icon", icon_to_json i) :: fields
+    | None -> fields
+  in
+  `Assoc fields
 
 let content_to_json = function
   | Text text -> `Assoc [
@@ -186,26 +311,34 @@ let content_to_json = function
 let tool_result_to_json (result : tool_result) =
   let content_json = `List (List.map content_to_json result.content) in
   let base = ["content", content_json] in
-  let with_error = match result.is_error with
+  let fields = match result.is_error with
     | Some true -> ("isError", `Bool true) :: base
     | _ -> base
   in
-  `Assoc with_error
+  let fields = match result._meta with
+    | Some m -> ("_meta", m) :: fields
+    | None -> fields
+  in
+  `Assoc fields
 
 let resource_to_json (res : resource) =
   let base = [
     "uri", `String res.uri;
     "name", `String res.name;
   ] in
-  let with_desc = match res.description with
+  let fields = match res.description with
     | Some d -> ("description", `String d) :: base
     | None -> base
   in
-  let with_mime = match res.mime_type with
-    | Some m -> ("mimeType", `String m) :: with_desc
-    | None -> with_desc
+  let fields = match res.mime_type with
+    | Some m -> ("mimeType", `String m) :: fields
+    | None -> fields
   in
-  `Assoc with_mime
+  let fields = match res.icon with
+    | Some i -> ("icon", icon_to_json i) :: fields
+    | None -> fields
+  in
+  `Assoc fields
 
 let resource_contents_to_json (rc : resource_contents) =
   let base = ["uri", `String rc.uri] in
@@ -237,22 +370,31 @@ let prompt_argument_to_json (arg : prompt_argument) =
 
 let prompt_to_json (p : prompt) =
   let base = ["name", `String p.name] in
-  let with_desc = match p.description with
+  let fields = match p.description with
     | Some d -> ("description", `String d) :: base
     | None -> base
   in
-  let with_args = match p.arguments with
-    | Some args -> ("arguments", `List (List.map prompt_argument_to_json args)) :: with_desc
-    | None -> with_desc
+  let fields = match p.arguments with
+    | Some args -> ("arguments", `List (List.map prompt_argument_to_json args)) :: fields
+    | None -> fields
   in
-  `Assoc with_args
+  let fields = match p.icon with
+    | Some i -> ("icon", icon_to_json i) :: fields
+    | None -> fields
+  in
+  `Assoc fields
 
 let initialize_result_to_json (result : initialize_result) =
-  `Assoc [
+  let base = [
     "protocolVersion", `String result.protocol_version;
     "capabilities", server_capabilities_to_json result.capabilities;
     "serverInfo", implementation_info_to_json result.server_info;
-  ]
+  ] in
+  let fields = match result._meta with
+    | Some m -> ("_meta", m) :: base
+    | None -> base
+  in
+  `Assoc fields
 
 (** {1 JSON Decoding} *)
 
@@ -261,13 +403,37 @@ let implementation_info_of_json json =
   {
     name = json |> member "name" |> to_string;
     version = json |> member "version" |> to_string;
+    description = (match json |> member "description" with
+      | `String s -> Some s
+      | _ -> None);
+  }
+
+let icon_of_json json =
+  let open Yojson.Safe.Util in
+  { uri = json |> member "uri" |> to_string }
+
+let tool_annotations_of_json json =
+  let open Yojson.Safe.Util in
+  {
+    title = (match json |> member "title" with `String s -> Some s | _ -> None);
+    read_only_hint = (match json |> member "readOnlyHint" with `Bool b -> Some b | _ -> None);
+    destructive_hint = (match json |> member "destructiveHint" with `Bool b -> Some b | _ -> None);
+    idempotent_hint = (match json |> member "idempotentHint" with `Bool b -> Some b | _ -> None);
+    open_world_hint = (match json |> member "openWorldHint" with `Bool b -> Some b | _ -> None);
+  }
+
+let roots_capability_of_json json =
+  let open Yojson.Safe.Util in
+  {
+    list_changed = (match json |> member "listChanged" with `Bool b -> Some b | _ -> None);
   }
 
 let client_capabilities_of_json json =
   let open Yojson.Safe.Util in
   {
-    roots = (match json |> member "roots" with `Null -> None | _ -> Some true);
-    sampling = (match json |> member "sampling" with `Null -> None | _ -> Some true);
+    roots = (match json |> member "roots" with `Null -> None | j -> Some (roots_capability_of_json j));
+    sampling = (match json |> member "sampling" with `Null -> None | _ -> Some ());
+    experimental = (match json |> member "experimental" with `Null -> None | j -> Some j);
   }
 
 let initialize_params_of_json json =
@@ -276,20 +442,32 @@ let initialize_params_of_json json =
     protocol_version = json |> member "protocolVersion" |> to_string;
     capabilities = json |> member "capabilities" |> client_capabilities_of_json;
     client_info = json |> member "clientInfo" |> implementation_info_of_json;
+    _meta = (match json |> member "_meta" with `Null -> None | m -> Some m);
   }
 
 let tool_call_of_json json =
   let open Yojson.Safe.Util in
   {
     name = json |> member "name" |> to_string;
-    arguments = match json |> member "arguments" with
+    arguments = (match json |> member "arguments" with
       | `Null -> None
-      | args -> Some args;
+      | args -> Some args);
+    _meta = (match json |> member "_meta" with `Null -> None | m -> Some m);
+  }
+
+let tool_of_json json =
+  let open Yojson.Safe.Util in
+  {
+    name = json |> member "name" |> to_string;
+    description = (match json |> member "description" with `String s -> Some s | _ -> None);
+    input_schema = json |> member "inputSchema";
+    annotations = (match json |> member "annotations" with `Null -> None | j -> Some (tool_annotations_of_json j));
+    icon = (match json |> member "icon" with `Null -> None | j -> Some (icon_of_json j));
   }
 
 (** {1 Protocol Version} *)
 
-let protocol_version = "2024-11-05"
+let protocol_version = "2025-11-25"
 
 (** {1 Method Names} *)
 
@@ -315,6 +493,12 @@ module Method = struct
   (* Logging *)
   let logging_set_level = "logging/setLevel"
 
+  (* Tasks — 2025-11-25 *)
+  let tasks_get = "tasks/get"
+  let tasks_result = "tasks/result"
+  let tasks_list = "tasks/list"
+  let tasks_cancel = "tasks/cancel"
+
   (* Notifications *)
   let cancelled = "notifications/cancelled"
   let progress = "notifications/progress"
@@ -322,4 +506,5 @@ module Method = struct
   let resources_list_changed = "notifications/resources/list_changed"
   let tools_list_changed = "notifications/tools/list_changed"
   let prompts_list_changed = "notifications/prompts/list_changed"
+  let tasks_status = "notifications/tasks/status"  (** Task status change (2025-11-25) *)
 end

--- a/lib/mcp/schema.ml
+++ b/lib/mcp/schema.ml
@@ -1,7 +1,7 @@
 (** Kirin MCP - JSON Schema Builder
 
     Helper functions to construct JSON Schema objects for tool input definitions.
-    Follows JSON Schema Draft-07 specification.
+    Default dialect: JSON Schema 2020-12 (per MCP 2025-11-25 spec).
 *)
 
 (** {1 Primitive Types} *)
@@ -205,3 +205,14 @@ let bool_with_default ~default ?description () =
   match base with
   | `Assoc fields -> `Assoc (("default", `Bool default) :: fields)
   | _ -> base
+
+(** {1 Dialect} *)
+
+(** Default JSON Schema dialect (2020-12 per MCP 2025-11-25 spec) *)
+let default_dialect = "https://json-schema.org/draft/2020-12/schema"
+
+(** Add $schema annotation to a schema object *)
+let with_dialect schema =
+  match schema with
+  | `Assoc fields -> `Assoc (("$schema", `String default_dialect) :: fields)
+  | _ -> schema

--- a/lib/mcp/session.ml
+++ b/lib/mcp/session.ml
@@ -35,6 +35,7 @@ let create ~server_name ~server_version () =
     server_info = {
       Protocol.name = server_name;
       version = server_version;
+      description = None;
     };
     server_capabilities = {
       Protocol.tools = None;
@@ -60,15 +61,18 @@ let is_closed t = t.state = Closed
 
 (** Enable tools capability *)
 let enable_tools t =
-  t.server_capabilities <- { t.server_capabilities with tools = Some true }
+  t.server_capabilities <- { t.server_capabilities with
+    tools = Some { Protocol.list_changed = None } }
 
 (** Enable resources capability *)
 let enable_resources t =
-  t.server_capabilities <- { t.server_capabilities with resources = Some true }
+  t.server_capabilities <- { t.server_capabilities with
+    resources = Some { Protocol.subscribe = None; list_changed = None } }
 
 (** Enable prompts capability *)
 let enable_prompts t =
-  t.server_capabilities <- { t.server_capabilities with prompts = Some true }
+  t.server_capabilities <- { t.server_capabilities with
+    prompts = Some { Protocol.list_changed = None } }
 
 (** Enable logging capability *)
 let enable_logging t =
@@ -93,6 +97,7 @@ let handle_initialize t (params : Protocol.initialize_params) =
       Protocol.protocol_version = Protocol.protocol_version;
       capabilities = t.server_capabilities;
       server_info = t.server_info;
+      _meta = None;
     }
   | _ ->
     Error "Session already initialized"

--- a/lib/mcp/tasks.ml
+++ b/lib/mcp/tasks.ml
@@ -1,0 +1,199 @@
+(** Kirin MCP - Tasks Primitive (2025-11-25)
+
+    Async/deferred tool execution via task state machine.
+    Tasks enable long-running operations that report progress
+    and deliver results asynchronously.
+*)
+
+(** {1 Types} *)
+
+(** Task state machine:
+    {v
+      Working ──┬── Completed
+                ├── Failed
+                ├── Cancelled
+                └── Input_required ── Working (resume)
+    v}
+*)
+type task_state =
+  | Working
+  | Input_required
+  | Completed
+  | Failed
+  | Cancelled
+
+(** Task record *)
+type task = {
+  id : string;
+  mutable state : task_state;
+  tool_name : string;
+  mutable progress : float option;
+  mutable progress_message : string option;
+  mutable result : Protocol.tool_result option;
+  mutable error : string option;
+}
+
+(** Task registry *)
+type registry = {
+  tasks : (string, task) Hashtbl.t;
+  mutable next_id : int;
+}
+
+(** {1 Constructor} *)
+
+(** Create a new task registry *)
+let create_registry () =
+  {
+    tasks = Hashtbl.create 16;
+    next_id = 1;
+  }
+
+(** {1 Task Operations} *)
+
+(** Create a new task for a tool execution *)
+let create_task registry ~tool_name =
+  let id = Printf.sprintf "task-%d" registry.next_id in
+  registry.next_id <- registry.next_id + 1;
+  let task = {
+    id;
+    state = Working;
+    tool_name;
+    progress = None;
+    progress_message = None;
+    result = None;
+    error = None;
+  } in
+  Hashtbl.replace registry.tasks id task;
+  task
+
+(** Update task progress (0.0 to 1.0) *)
+let update_progress registry ~id ~progress ?message () =
+  match Hashtbl.find_opt registry.tasks id with
+  | Some task when task.state = Working ->
+    task.progress <- Some progress;
+    task.progress_message <- message;
+    Ok ()
+  | Some _ -> Error "Task is not in working state"
+  | None -> Error (Printf.sprintf "Task not found: %s" id)
+
+(** Complete a task with a result *)
+let complete_task registry ~id ~result =
+  match Hashtbl.find_opt registry.tasks id with
+  | Some task when task.state = Working ->
+    task.state <- Completed;
+    task.result <- Some result;
+    task.progress <- Some 1.0;
+    Ok ()
+  | Some _ -> Error "Task is not in working state"
+  | None -> Error (Printf.sprintf "Task not found: %s" id)
+
+(** Fail a task with an error message *)
+let fail_task registry ~id ~error =
+  match Hashtbl.find_opt registry.tasks id with
+  | Some task when task.state = Working ->
+    task.state <- Failed;
+    task.error <- Some error;
+    Ok ()
+  | Some _ -> Error "Task is not in working state"
+  | None -> Error (Printf.sprintf "Task not found: %s" id)
+
+(** Cancel a task *)
+let cancel_task registry ~id =
+  match Hashtbl.find_opt registry.tasks id with
+  | Some task when task.state = Working || task.state = Input_required ->
+    task.state <- Cancelled;
+    Ok ()
+  | Some _ -> Error "Task cannot be cancelled in current state"
+  | None -> Error (Printf.sprintf "Task not found: %s" id)
+
+(** Request input from client *)
+let request_input registry ~id =
+  match Hashtbl.find_opt registry.tasks id with
+  | Some task when task.state = Working ->
+    task.state <- Input_required;
+    Ok ()
+  | Some _ -> Error "Task is not in working state"
+  | None -> Error (Printf.sprintf "Task not found: %s" id)
+
+(** Resume a task after input received *)
+let resume_task registry ~id =
+  match Hashtbl.find_opt registry.tasks id with
+  | Some task when task.state = Input_required ->
+    task.state <- Working;
+    Ok ()
+  | Some _ -> Error "Task is not in input_required state"
+  | None -> Error (Printf.sprintf "Task not found: %s" id)
+
+(** Get a task by ID *)
+let get_task registry ~id =
+  Hashtbl.find_opt registry.tasks id
+
+(** List all tasks *)
+let list_tasks registry =
+  Hashtbl.fold (fun _id task acc -> task :: acc) registry.tasks []
+
+(** {1 JSON Encoding} *)
+
+let task_state_to_string = function
+  | Working -> "working"
+  | Input_required -> "input_required"
+  | Completed -> "completed"
+  | Failed -> "failed"
+  | Cancelled -> "cancelled"
+
+let task_state_of_string = function
+  | "working" -> Ok Working
+  | "input_required" -> Ok Input_required
+  | "completed" -> Ok Completed
+  | "failed" -> Ok Failed
+  | "cancelled" -> Ok Cancelled
+  | s -> Error (Printf.sprintf "Unknown task state: %s" s)
+
+let task_to_json task =
+  let base = [
+    "id", `String task.id;
+    "state", `String (task_state_to_string task.state);
+    "toolName", `String task.tool_name;
+  ] in
+  let with_progress = match task.progress with
+    | Some p -> ("progress", `Float p) :: base
+    | None -> base
+  in
+  let with_message = match task.progress_message with
+    | Some m -> ("progressMessage", `String m) :: with_progress
+    | None -> with_progress
+  in
+  let with_result = match task.result with
+    | Some r -> ("result", Protocol.tool_result_to_json r) :: with_message
+    | None -> with_message
+  in
+  let with_error = match task.error with
+    | Some e -> ("error", `String e) :: with_result
+    | None -> with_result
+  in
+  `Assoc with_error
+
+let task_of_json json =
+  let open Yojson.Safe.Util in
+  let id = json |> member "id" |> to_string in
+  let state_str = json |> member "state" |> to_string in
+  let tool_name = json |> member "toolName" |> to_string in
+  match task_state_of_string state_str with
+  | Ok state ->
+    Ok {
+      id;
+      state;
+      tool_name;
+      progress = (match json |> member "progress" with
+        | `Float f -> Some f
+        | `Int i -> Some (Float.of_int i)
+        | _ -> None);
+      progress_message = (match json |> member "progressMessage" with
+        | `String s -> Some s
+        | _ -> None);
+      result = None;  (* Result is parsed separately via tasks/result *)
+      error = (match json |> member "error" with
+        | `String s -> Some s
+        | _ -> None);
+    }
+  | Error msg -> Error msg

--- a/lib/mcp_adapter.ml
+++ b/lib/mcp_adapter.ml
@@ -79,13 +79,15 @@ let tool_of_json_handler ~name ~description ~(schema : Yojson.Safe.t)
     name;
     description = Some description;
     input_schema = schema;
+    annotations = None;
+    icon = None;
   } in
   (tool, handler)
 
-(** Create Kirin routes for MCP server (HTTP+SSE transport)
+(** Create Kirin routes for MCP server (Streamable HTTP transport, 2025-11-25)
 
     Returns routes for:
-    - POST /mcp - Handle JSON-RPC requests
+    - POST /mcp - Handle JSON-RPC requests (immediate or streaming response)
     - GET /mcp/sse - SSE endpoint for server-to-client messages
 
     {[
@@ -149,16 +151,17 @@ let routes ?(prefix = "/mcp") (server : Server.t) : Router.route list =
     Router.options prefix handle_options;
   ]
 
-(** Create an HTTP+SSE MCP client transport.
+(** Create a Streamable HTTP MCP client transport (2025-11-25).
 
     Note: For a production client, you'd need to handle:
     1. HTTP POST requests to the MCP endpoint
-    2. SSE connection for server-initiated messages
+    2. Optional GET SSE for server-initiated messages
+    3. Mcp-Session-Id header management
 
     For now, this returns the basic transport structure.
 *)
 let create_http_client () =
-  Transport.of_http_sse ()
+  Transport.create_streamable_http ()
 
 (** {1 Quick Access} *)
 


### PR DESCRIPTION
## Summary

- MCP 프로토콜 `2024-11-05` → `2025-11-25` 업그레이드
- Streamable HTTP transport (HTTP+SSE 대체, 단일 `/mcp` 엔드포인트)
- Tasks primitive 추가 (비동기 tool 실행, 상태 머신 + 레지스트리)
- Tool annotations, icons, `_meta` 필드, 구조화된 capabilities, Session ID 관리
- JSON Schema 2020-12 기본 dialect

## Changes (12 files, +890/-91)

| File | Description |
|------|-------------|
| `lib/mcp/protocol.ml` | Version bump, 구조화된 capabilities, icons, tool annotations, `_meta`, Task methods |
| `lib/mcp/tasks.ml` | **NEW** — Task 상태 머신, registry, CRUD, JSON encoding (199 LOC) |
| `lib/mcp/transport.ml` | `Http_sse` → `Streamable_http`, session ID, protocol version header |
| `lib/mcp/server.ml` | Tasks dispatch (get/list/cancel/result), task_registry 필드 |
| `lib/mcp/session.ml` | 구조화된 capabilities, description 필드 |
| `lib/mcp/schema.ml` | JSON Schema 2020-12 dialect, `with_dialect` helper |
| `lib/mcp/jsonrpc.ml` | `extract_meta` helper |
| `lib/mcp/client.ml` | 구조화된 capabilities 파싱, 새 필드 지원 |
| `lib/mcp/kirin_mcp.ml` | `Tasks` 모듈 re-export |
| `lib/mcp_adapter.ml` | Streamable HTTP transport, record 필드 업데이트 |
| `examples/mcp_client/main.ml` | Streamable HTTP API 사용으로 업데이트 |
| `test/test_mcp.ml` | 22개 기존 테스트 수정 + 21개 신규 = **43 tests passing** |

## Test plan

- [x] `dune build --root .` — clean build, no warnings
- [x] `dune runtest --root .` — 43/43 tests pass (0.004s)
- [x] Zero references to old `2024-11-05` protocol version
- [x] Zero references to old `Http_sse` / `of_http_sse` API
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)