### PR TITLE
fix(mcp): correct wire format for MCP 2025-11-25 compliance

### DIFF
--- a/lib/mcp/dune
+++ b/lib/mcp/dune
@@ -1,5 +1,5 @@
 (library
  (name kirin_mcp)
  (public_name kirin.mcp)
- (libraries yojson eio)
+ (libraries yojson eio unix)
  (instrumentation (backend bisect_ppx)))

--- a/lib/mcp/jsonrpc.ml
+++ b/lib/mcp/jsonrpc.ml
@@ -110,7 +110,7 @@ let encode_response (resp : response) =
   let with_result = match resp.result, resp.error with
     | Some r, None -> base @ ["result", r]
     | None, Some e -> base @ ["error", error_to_json e]
-    | Some r, Some _ -> base @ ["result", r]  (* Result takes precedence *)
+    | Some _, Some e -> base @ ["error", error_to_json e]  (* Error takes precedence per JSON-RPC 2.0 *)
     | None, None -> base @ ["result", `Null]
   in
   `Assoc with_result

--- a/lib/mcp/server.ml
+++ b/lib/mcp/server.ml
@@ -206,7 +206,7 @@ let handle_request t (req : Jsonrpc.request) : Jsonrpc.response =
   | m when m = tasks_get ->
     (match req.params with
      | Some params ->
-       let id = Yojson.Safe.Util.(params |> member "id" |> to_string) in
+       let id = Yojson.Safe.Util.(params |> member "taskId" |> to_string) in
        (match Tasks.get_task t.task_registry ~id with
         | Some task ->
           Jsonrpc.success_response ~id:req.id
@@ -227,7 +227,7 @@ let handle_request t (req : Jsonrpc.request) : Jsonrpc.response =
   | m when m = tasks_cancel ->
     (match req.params with
      | Some params ->
-       let id = Yojson.Safe.Util.(params |> member "id" |> to_string) in
+       let id = Yojson.Safe.Util.(params |> member "taskId" |> to_string) in
        (match Tasks.cancel_task t.task_registry ~id with
         | Ok () ->
           Jsonrpc.success_response ~id:req.id (`Assoc [])
@@ -242,7 +242,7 @@ let handle_request t (req : Jsonrpc.request) : Jsonrpc.response =
   | m when m = tasks_result ->
     (match req.params with
      | Some params ->
-       let id = Yojson.Safe.Util.(params |> member "id" |> to_string) in
+       let id = Yojson.Safe.Util.(params |> member "taskId" |> to_string) in
        (match Tasks.get_task t.task_registry ~id with
         | Some task when task.state = Tasks.Completed ->
           (match task.result with

--- a/lib/mcp/tasks.ml
+++ b/lib/mcp/tasks.ml
@@ -31,6 +31,8 @@ type task = {
   mutable progress_message : string option;
   mutable result : Protocol.tool_result option;
   mutable error : string option;
+  created_at : float;    (** Unix timestamp when task was created *)
+  mutable updated_at : float;  (** Unix timestamp of last state change *)
 }
 
 (** Task registry *)
@@ -54,6 +56,7 @@ let create_registry () =
 let create_task registry ~tool_name =
   let id = Printf.sprintf "task-%d" registry.next_id in
   registry.next_id <- registry.next_id + 1;
+  let now = Unix.gettimeofday () in
   let task = {
     id;
     state = Working;
@@ -62,6 +65,8 @@ let create_task registry ~tool_name =
     progress_message = None;
     result = None;
     error = None;
+    created_at = now;
+    updated_at = now;
   } in
   Hashtbl.replace registry.tasks id task;
   task
@@ -72,6 +77,7 @@ let update_progress registry ~id ~progress ?message () =
   | Some task when task.state = Working ->
     task.progress <- Some progress;
     task.progress_message <- message;
+    task.updated_at <- Unix.gettimeofday ();
     Ok ()
   | Some _ -> Error "Task is not in working state"
   | None -> Error (Printf.sprintf "Task not found: %s" id)
@@ -83,6 +89,7 @@ let complete_task registry ~id ~result =
     task.state <- Completed;
     task.result <- Some result;
     task.progress <- Some 1.0;
+    task.updated_at <- Unix.gettimeofday ();
     Ok ()
   | Some _ -> Error "Task is not in working state"
   | None -> Error (Printf.sprintf "Task not found: %s" id)
@@ -93,6 +100,7 @@ let fail_task registry ~id ~error =
   | Some task when task.state = Working ->
     task.state <- Failed;
     task.error <- Some error;
+    task.updated_at <- Unix.gettimeofday ();
     Ok ()
   | Some _ -> Error "Task is not in working state"
   | None -> Error (Printf.sprintf "Task not found: %s" id)
@@ -102,6 +110,7 @@ let cancel_task registry ~id =
   match Hashtbl.find_opt registry.tasks id with
   | Some task when task.state = Working || task.state = Input_required ->
     task.state <- Cancelled;
+    task.updated_at <- Unix.gettimeofday ();
     Ok ()
   | Some _ -> Error "Task cannot be cancelled in current state"
   | None -> Error (Printf.sprintf "Task not found: %s" id)
@@ -111,6 +120,7 @@ let request_input registry ~id =
   match Hashtbl.find_opt registry.tasks id with
   | Some task when task.state = Working ->
     task.state <- Input_required;
+    task.updated_at <- Unix.gettimeofday ();
     Ok ()
   | Some _ -> Error "Task is not in working state"
   | None -> Error (Printf.sprintf "Task not found: %s" id)
@@ -120,6 +130,7 @@ let resume_task registry ~id =
   match Hashtbl.find_opt registry.tasks id with
   | Some task when task.state = Input_required ->
     task.state <- Working;
+    task.updated_at <- Unix.gettimeofday ();
     Ok ()
   | Some _ -> Error "Task is not in input_required state"
   | None -> Error (Printf.sprintf "Task not found: %s" id)
@@ -136,14 +147,14 @@ let list_tasks registry =
 
 let task_state_to_string = function
   | Working -> "working"
-  | Input_required -> "input_required"
+  | Input_required -> "inputRequired"
   | Completed -> "completed"
   | Failed -> "failed"
   | Cancelled -> "cancelled"
 
 let task_state_of_string = function
   | "working" -> Ok Working
-  | "input_required" -> Ok Input_required
+  | "inputRequired" | "input_required" -> Ok Input_required
   | "completed" -> Ok Completed
   | "failed" -> Ok Failed
   | "cancelled" -> Ok Cancelled
@@ -151,7 +162,7 @@ let task_state_of_string = function
 
 let task_to_json task =
   let base = [
-    "id", `String task.id;
+    "taskId", `String task.id;
     "state", `String (task_state_to_string task.state);
     "toolName", `String task.tool_name;
   ] in
@@ -171,11 +182,16 @@ let task_to_json task =
     | Some e -> ("error", `String e) :: with_result
     | None -> with_result
   in
-  `Assoc with_error
+  let with_timestamps =
+    ("createdAt", `Float task.created_at)
+    :: ("updatedAt", `Float task.updated_at)
+    :: with_error
+  in
+  `Assoc with_timestamps
 
 let task_of_json json =
   let open Yojson.Safe.Util in
-  let id = json |> member "id" |> to_string in
+  let id = json |> member "taskId" |> to_string in
   let state_str = json |> member "state" |> to_string in
   let tool_name = json |> member "toolName" |> to_string in
   match task_state_of_string state_str with
@@ -195,5 +211,13 @@ let task_of_json json =
       error = (match json |> member "error" with
         | `String s -> Some s
         | _ -> None);
+      created_at = (match json |> member "createdAt" with
+        | `Float f -> f
+        | `Int i -> Float.of_int i
+        | _ -> 0.0);
+      updated_at = (match json |> member "updatedAt" with
+        | `Float f -> f
+        | `Int i -> Float.of_int i
+        | _ -> 0.0);
     }
   | Error msg -> Error msg

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -408,12 +408,14 @@ let test_tasks_json_roundtrip () =
 
 let test_tasks_state_strings () =
   check string "working" "working" (T.task_state_to_string T.Working);
-  check string "input_required" "input_required" (T.task_state_to_string T.Input_required);
+  check string "inputRequired" "inputRequired" (T.task_state_to_string T.Input_required);
   check string "completed" "completed" (T.task_state_to_string T.Completed);
   check string "failed" "failed" (T.task_state_to_string T.Failed);
   check string "cancelled" "cancelled" (T.task_state_to_string T.Cancelled);
   (* Round-trip *)
   check bool "working rt" true (T.task_state_of_string "working" = Ok T.Working);
+  check bool "inputRequired rt" true (T.task_state_of_string "inputRequired" = Ok T.Input_required);
+  check bool "input_required compat" true (T.task_state_of_string "input_required" = Ok T.Input_required);
   check bool "unknown fails" true (Result.is_error (T.task_state_of_string "bogus"))
 
 let tasks_tests = [


### PR DESCRIPTION
## Summary

Post-merge audit of PR #13 (MCP 2025-11-25 upgrade) against TypeScript SDK and Python SDK reference implementations revealed wire format serialization bugs that would break interoperability with standard MCP clients.

**Fixes (PR A — critical wire format)**:
- `tasks.ml`: camelCase `"inputRequired"` on wire (was snake_case `"input_required"`)
- `tasks.ml`: `"taskId"` field name in JSON (was `"id"`)
- `tasks.ml`: `createdAt`/`updatedAt` timestamp fields added to task records and JSON encoding/decoding
- `server.ml`: param key `"taskId"` in `tasks/get`, `tasks/cancel`, `tasks/result` handlers
- `jsonrpc.ml`: error takes precedence over result when both present (JSON-RPC 2.0 §5.1)
- `dune`: `unix` library dependency for `Unix.gettimeofday()`

**Backward compatibility**:
- `task_state_of_string` accepts both `"inputRequired"` (spec) and `"input_required"` (legacy)

## Test plan
- [x] All 43 MCP tests pass
- [x] All 22 test suites pass (1,000+ total tests)
- [x] Backward-compat round-trip test for both inputRequired variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)