### PR TITLE
fix(mcp): improve API surface for 2025-11-25 compliance

### DIFF
--- a/examples/mcp_server/main.ml
+++ b/examples/mcp_server/main.ml
@@ -24,7 +24,7 @@ let () =
       let open Yojson.Safe.Util in
       let name = params |> member "name" |> to_string in
       `String (Printf.sprintf "Hello, %s! Welcome to Kirin MCP." name)
-    );
+    ) ();
 
   (* Register a calculator tool *)
   Mcp.Server.add_tool mcp
@@ -45,7 +45,7 @@ let () =
       let a = params |> member "a" |> to_number in
       let b = params |> member "b" |> to_number in
       `Float (a +. b)
-    );
+    ) ();
 
   (* Register a time resource *)
   Mcp.Server.add_resource mcp

--- a/lib/mcp/server.ml
+++ b/lib/mcp/server.ml
@@ -56,15 +56,16 @@ let create ?(name = "kirin-mcp") ?(version = "1.0.0") () =
 
 (** {1 Tool Registration} *)
 
-(** Add a tool to the server *)
-let add_tool t ~name ~description ~schema ~handler =
+(** Add a tool to the server.
+    [?annotations] and [?icon] are optional 2025-11-25 fields. *)
+let add_tool t ~name ~description ~schema ?annotations ?icon ~handler () =
   Session.enable_tools t.session;
   let tool = {
     Protocol.name;
     description = Some description;
     input_schema = schema;
-    annotations = None;
-    icon = None;
+    annotations;
+    icon;
   } in
   t.tools <- { tool; handler } :: t.tools
 
@@ -89,14 +90,14 @@ let call_tool t ~name ~arguments =
 (** {1 Resource Registration} *)
 
 (** Add a resource to the server *)
-let add_resource t ~uri ~name ?description ?mime_type ~handler () =
+let add_resource t ~uri ~name ?description ?mime_type ?icon ~handler () =
   Session.enable_resources t.session;
   let resource = {
     Protocol.uri;
     name;
     description;
     mime_type;
-    icon = None;
+    icon;
   } in
   t.resources <- { resource; handler } :: t.resources
 
@@ -121,13 +122,13 @@ let read_resource t ~uri =
 (** {1 Prompt Registration} *)
 
 (** Add a prompt to the server *)
-let add_prompt t ~name ?description ?arguments ?handler () =
+let add_prompt t ~name ?description ?arguments ?icon ?handler () =
   Session.enable_prompts t.session;
   let prompt = {
     Protocol.name;
     description;
     arguments;
-    icon = None;
+    icon;
   } in
   t.prompts <- { prompt; handler } :: t.prompts
 


### PR DESCRIPTION
## Summary

PR B in the MCP 2025-11-25 upgrade series (after PR #14 wire format fixes).

Improves the public API surface to match the 2025-11-25 specification:

- **Tool/Resource/Prompt registration**: `Server.add_tool`, `add_resource`, `add_prompt` now accept optional `?annotations`, `?icon` parameters (with trailing `()` for OCaml optional argument resolution)
- **Session ID**: `Session.handle_initialize` generates a 24-char hex session ID from timestamp + random bits, accessible via `Session.session_id`
- **Task state change callbacks**: `Tasks.registry` supports `?on_state_change` constructor param and `set_on_state_change` for late binding — fires on every state transition for decoupled notification delivery

## Changes

| File | What |
|------|------|
| `lib/mcp/server.ml` | Optional `?annotations ?icon` on registration functions |
| `lib/mcp/session.ml` | Session ID generation + accessor |
| `lib/mcp/tasks.ml` | `on_state_change` callback system (6 mutation points) |
| `examples/mcp_server/main.ml` | Fix `add_tool` callers for trailing `()` |
| `test/test_mcp.ml` | 5 caller fixes + 4 new tests |

## Test plan

- [x] `dune runtest` — 197 tests pass (47 MCP tests, 0 failures)
- [x] Session ID is exactly 24 hex chars after initialization
- [x] Callback fires on every state transition (progress, complete, fail, cancel)
- [x] Late-bound callback via `set_on_state_change` works
- [x] Tool annotations and icon round-trip through registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)