### PR TITLE
fix(mcp): CSPRNG session IDs + test coverage (52→66)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -8,7 +8,7 @@
 
 (test
  (name test_mcp)
- (libraries kirin kirin.mcp alcotest str))
+ (libraries kirin kirin.mcp alcotest str eio eio_main))
 
 (test
  (name test_openapi)


### PR DESCRIPTION
## Summary

- **Security fix**: Session ID generation now uses `/dev/urandom` (128-bit CSPRNG) instead of predictable `Random.bits()`. Produces 32 hex chars, same pattern as `lib/auth/secure_random.ml`.
- **Test coverage**: Added 14 new tests for previously untested MCP modules.

## Changes

| File | Change |
|------|--------|
| `lib/mcp/session.ml` | `/dev/urandom` CSPRNG replaces `Random.bits()` |
| `test/dune` | Added `eio eio_main` to test_mcp libraries |
| `test/test_mcp.ml` | +181 LOC: 14 new tests |

## New Tests

| Suite | Count | Coverage |
|-------|-------|----------|
| Transport | 6 | stdio create, streamable HTTP create, session ID (stdio/streamable), queue message, queue-on-stdio error |
| Client | 3 | create initial state, next_id increment, 100-ID monotonicity |
| Tasks | 3 | complete-from-failed error, fail-from-completed error, not-found operations |
| Session | 2 | ID uniqueness (two sessions differ), hex format validation |
| **Total new** | **14** | MCP tests: 52 → 66 |

## Test plan

- [x] `dune build --root .` — zero warnings
- [x] `dune runtest --root . --force` — all 66 MCP tests pass
- [x] Session ID is 32 hex chars from `/dev/urandom`
- [ ] CI: lint, ubuntu 5.1/5.2, macOS 5.1/5.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)