### PR TITLE
refactor: migrate to mcp-protocol-sdk v0.13.0 shared modules

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -62,6 +62,7 @@ Features:
   (graphql (>= "0.14.0"))
   (graphql_parser (>= "0.14.0"))
   (hmap (>= "0.8"))
+  (mcp_protocol_eio (>= "0.13.0"))
   (bisect_ppx (and (>= 2.8) :with-dev-setup))
   (alcotest :with-test)
   (odoc :with-doc))

--- a/kirin.opam
+++ b/kirin.opam
@@ -61,6 +61,7 @@ depends: [
   "graphql" {>= "0.14.0"}
   "graphql_parser" {>= "0.14.0"}
   "hmap" {>= "0.8"}
+  "mcp_protocol_eio" {>= "0.13.0"}
   "bisect_ppx" {>= "2.8" & with-dev-setup}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/lib/dune
+++ b/lib/dune
@@ -30,7 +30,8 @@
   unix
   threads
   str
-  dune-build-info)
+  dune-build-info
+  mcp_protocol_eio)
  (preprocess
   (pps ppx_deriving.show ppx_deriving_yojson))
  (instrumentation (backend bisect_ppx)))

--- a/lib/time_compat.ml
+++ b/lib/time_compat.ml
@@ -1,35 +1,4 @@
-(** Time Compatibility Layer - Eio-native timestamps with fallback
+(** Time Compatibility Layer - re-exported from mcp-protocol-sdk.
 
-    Provides a unified timestamp API for gradual migration from
-    Unix.gettimeofday to Eio.Time.now.
-
-    Usage:
-    1. At server startup: [Time_compat.set_clock (Eio.Stdenv.clock env)]
-    2. In code: [Time_compat.now ()] instead of [Unix.gettimeofday ()]
-
-    When clock is not set (non-Eio contexts), falls back to Unix.gettimeofday.
-    This allows incremental migration without changing all call sites at once.
-
-    @since 2026-02 - Async blocking pattern fixes
-*)
-
-(** Global clock reference - set at Eio_main.run startup *)
-let global_clock : float Eio.Time.clock_ty Eio.Resource.t option ref = ref None
-
-(** Set the global Eio clock. Call once at server startup.
-    @param clock The Eio clock from [Eio.Stdenv.clock env] *)
-let set_clock clock = global_clock := Some clock
-
-(** Get current timestamp using Eio clock if available, Unix fallback otherwise.
-    @return Current time as float (seconds since Unix epoch) *)
-let now () =
-  match !global_clock with
-  | Some clock -> Eio.Time.now clock
-  | None -> Unix.gettimeofday ()
-
-(** Sleep for given duration using Eio if available, Unix fallback otherwise.
-    @param seconds Duration to sleep *)
-let sleep seconds =
-  match !global_clock with
-  | Some clock -> Eio.Time.sleep clock seconds
-  | None -> Unix.sleepf seconds
+    @since 1.1.0 - Migrated to mcp-protocol-sdk shared module *)
+include Mcp_protocol_eio.Time_compat


### PR DESCRIPTION
## Summary
- Replace local `time_compat.ml` with re-export from `Mcp_protocol_eio.Time_compat`
- Add `mcp_protocol_eio` as new dependency (>= 0.13.0)

## Test plan
- [x] `dune build --root .` passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)