### PR TITLE
fix(ci): add mcp_protocol opam pins for dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
 
     - name: Pin internal opam deps (not published on opam-repository)
       run: |
+        opam pin add -n -y mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main
+        opam pin add -n -y mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#main
+        opam pin add -n -y mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#main
         opam pin add -n -y grpc-direct https://github.com/jeong-sik/grpc-direct.git#main
         opam pin add -n -y grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main
         opam pin add -n -y ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main
@@ -78,6 +81,9 @@ jobs:
 
     - name: Pin internal opam deps (not published on opam-repository)
       run: |
+        opam pin add -n -y mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main
+        opam pin add -n -y mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#main
+        opam pin add -n -y mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#main
         opam pin add -n -y grpc-direct https://github.com/jeong-sik/grpc-direct.git#main
         opam pin add -n -y grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main
         opam pin add -n -y ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main
@@ -132,6 +138,9 @@ jobs:
 
     - name: Pin internal opam deps (not published on opam-repository)
       run: |
+        opam pin add -n -y mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main
+        opam pin add -n -y mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#main
+        opam pin add -n -y mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#main
         opam pin add -n -y grpc-direct https://github.com/jeong-sik/grpc-direct.git#main
         opam pin add -n -y grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main
         opam pin add -n -y ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main


### PR DESCRIPTION
## Summary
- Add `mcp_protocol`, `mcp_protocol_eio`, and `mcp_protocol_http` opam pins from GitHub in all CI jobs (build, coverage, benchmark)
- These packages are not published on opam-repository, causing `opam install --deps-only` to fail
- Place mcp pins before `ocaml-webrtc` pin since ocaml-webrtc depends on `mcp_protocol_eio`

## Test plan
- [ ] CI build job passes on all matrix combinations
- [ ] CI coverage job passes
- [ ] CI benchmark job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)