### PR TITLE
fix: protect concurrent mutable state across SSR engines

### DIFF
--- a/lib/lit/ssr.ml
+++ b/lib/lit/ssr.ml
@@ -38,7 +38,7 @@ type worker_state =
 (** Worker *)
 type worker = {
   mutable state: worker_state;
-  mutable request_count: int;
+  request_count: int Atomic.t;
   mutable last_error: string option;
 }
 
@@ -46,11 +46,11 @@ type worker = {
 type t = {
   config: ssr_config;
   workers: worker array;
-  mutable total_renders: int;
-  mutable errors: int;
-  mutable timeouts: int;
-  mutable cache_hits: int;
-  mutable cache_misses: int;
+  total_renders: int Atomic.t;
+  errors: int Atomic.t;
+  timeouts: int Atomic.t;
+  cache_hits: int Atomic.t;
+  cache_misses: int Atomic.t;
 }
 
 (** SSR statistics *)
@@ -69,17 +69,17 @@ type ssr_stats = {
 let create config =
   let workers = Array.init config.pool_size (fun _ -> {
     state = Idle;
-    request_count = 0;
+    request_count = Atomic.make 0;
     last_error = None;
   }) in
   {
     config;
     workers;
-    total_renders = 0;
-    errors = 0;
-    timeouts = 0;
-    cache_hits = 0;
-    cache_misses = 0;
+    total_renders = Atomic.make 0;
+    errors = Atomic.make 0;
+    timeouts = Atomic.make 0;
+    cache_hits = Atomic.make 0;
+    cache_misses = Atomic.make 0;
   }
 
 (** {1 Rendering} *)
@@ -136,8 +136,8 @@ let render_internal engine ~tag_name ?(props = `Null) ?(slots = []) () =
 
 (** Render component *)
 let render engine ~tag_name ?props ?slots () =
-  engine.total_renders <- engine.total_renders + 1;
-  engine.cache_misses <- engine.cache_misses + 1;
+  ignore (Atomic.fetch_and_add engine.total_renders 1);
+  ignore (Atomic.fetch_and_add engine.cache_misses 1);
   match render_internal engine ~tag_name ?props ?slots () with
   | Ok result ->
     let html = if engine.config.include_polyfill then
@@ -147,7 +147,7 @@ let render engine ~tag_name ?props ?slots () =
     in
     Ok html
   | Error msg ->
-    engine.errors <- engine.errors + 1;
+    ignore (Atomic.fetch_and_add engine.errors 1);
     Error msg
 
 (** Render with fallback *)
@@ -224,12 +224,14 @@ let stats engine =
   let active = Array.fold_left (fun acc w ->
     if w.state <> Dead then acc + 1 else acc
   ) 0 engine.workers in
-  let total = engine.cache_hits + engine.cache_misses in
-  let hit_rate = if total > 0 then float_of_int engine.cache_hits /. float_of_int total else 0.0 in
+  let hits = Atomic.get engine.cache_hits in
+  let misses = Atomic.get engine.cache_misses in
+  let total = hits + misses in
+  let hit_rate = if total > 0 then float_of_int hits /. float_of_int total else 0.0 in
   {
-    stat_total_renders = engine.total_renders;
-    stat_errors = engine.errors;
-    stat_timeouts = engine.timeouts;
+    stat_total_renders = Atomic.get engine.total_renders;
+    stat_errors = Atomic.get engine.errors;
+    stat_timeouts = Atomic.get engine.timeouts;
     stat_avg_time_ms = 0.0;  (* Would track actual times *)
     stat_cache_hit_rate = hit_rate;
     stat_active_workers = active;

--- a/lib/parallel.ml
+++ b/lib/parallel.ml
@@ -203,32 +203,32 @@ module Pool = struct
 
   type t = {
     size : int;
-    mutable active : bool;
+    active : bool Atomic.t;
   }
 
   (** Create a domain pool *)
   let create ?(size = recommended_domains ()) () = {
     size;
-    active = true;
+    active = Atomic.make true;
   }
 
   (** Map using domain pool *)
   let map pool f items =
-    if not pool.active then
+    if not (Atomic.get pool.active) then
       failwith "Domain pool is shut down"
     else
       map ~domains:pool.size f items
 
   (** Iter using domain pool *)
   let iter pool f items =
-    if not pool.active then
+    if not (Atomic.get pool.active) then
       failwith "Domain pool is shut down"
     else
       iter ~domains:pool.size f items
 
   (** Reduce using domain pool *)
   let reduce pool combine init items =
-    if not pool.active then
+    if not (Atomic.get pool.active) then
       failwith "Domain pool is shut down"
     else
       reduce ~domains:pool.size combine init items
@@ -237,11 +237,11 @@ module Pool = struct
   let size pool = pool.size
 
   (** Check if pool is active *)
-  let is_active pool = pool.active
+  let is_active pool = Atomic.get pool.active
 
   (** Shutdown the pool *)
   let shutdown pool =
-    pool.active <- false
+    Atomic.set pool.active false
 end
 
 (** {1 Utilities} *)

--- a/lib/solid/ssr.ml
+++ b/lib/solid/ssr.ml
@@ -30,10 +30,10 @@ let default_config ~bundle = {
 type t = {
   config: config;
   mutable pool: Worker.t array;
-  mutable next_worker: int;
-  mutable total_renders: int;
-  mutable errors: int;
-  mutable timeouts: int;
+  next_worker: int Atomic.t;
+  total_renders: int Atomic.t;
+  errors: int Atomic.t;
+  timeouts: int Atomic.t;
   cache: (string, Protocol.render_response) Hashtbl.t;
   cache_max_size: int;
 }
@@ -50,10 +50,10 @@ let create config =
   {
     config;
     pool;
-    next_worker = 0;
-    total_renders = 0;
-    errors = 0;
-    timeouts = 0;
+    next_worker = Atomic.make 0;
+    total_renders = Atomic.make 0;
+    errors = Atomic.make 0;
+    timeouts = Atomic.make 0;
     cache = Hashtbl.create 256;
     cache_max_size = 1000;
   }
@@ -75,7 +75,7 @@ let shutdown engine =
 
 (** Get next available worker (round-robin) *)
 let get_worker engine =
-  let start = engine.next_worker in
+  let start = Atomic.get engine.next_worker in
   let n = Array.length engine.pool in
   let rec find i =
     if i >= n then None
@@ -83,7 +83,7 @@ let get_worker engine =
       let idx = (start + i) mod n in
       let worker = engine.pool.(idx) in
       if Worker.is_ready worker then begin
-        engine.next_worker <- (idx + 1) mod n;
+        Atomic.set engine.next_worker ((idx + 1) mod n);
         Some worker
       end else
         find (i + 1)
@@ -110,41 +110,41 @@ let render_cached engine ~url ?(props = `Assoc []) () =
   (* Check cache *)
   match Hashtbl.find_opt engine.cache key with
   | Some response ->
-    engine.total_renders <- engine.total_renders + 1;
+    ignore (Atomic.fetch_and_add engine.total_renders 1);
     Ok response
   | None ->
     (* Get worker *)
     match get_worker engine with
     | None ->
-      engine.errors <- engine.errors + 1;
+      ignore (Atomic.fetch_and_add engine.errors 1);
       Error "No workers available"
     | Some worker ->
       let _ = ensure_worker_ready worker in
       match Worker.render worker ~url ~props () with
       | Ok response ->
-        engine.total_renders <- engine.total_renders + 1;
+        ignore (Atomic.fetch_and_add engine.total_renders 1);
         (* Cache if under limit *)
         if Hashtbl.length engine.cache < engine.cache_max_size then
           Hashtbl.replace engine.cache key response;
         Ok response
       | Error msg ->
-        engine.errors <- engine.errors + 1;
+        ignore (Atomic.fetch_and_add engine.errors 1);
         Error msg
 
 (** Render without caching *)
 let render engine ~url ?(props = `Assoc []) () =
   match get_worker engine with
   | None ->
-    engine.errors <- engine.errors + 1;
+    ignore (Atomic.fetch_and_add engine.errors 1);
     Error "No workers available"
   | Some worker ->
     let _ = ensure_worker_ready worker in
     match Worker.render worker ~url ~props () with
     | Ok response ->
-      engine.total_renders <- engine.total_renders + 1;
+      ignore (Atomic.fetch_and_add engine.total_renders 1);
       Ok response
     | Error msg ->
-      engine.errors <- engine.errors + 1;
+      ignore (Atomic.fetch_and_add engine.errors 1);
       Error msg
 
 (** Render with fallback *)
@@ -186,16 +186,17 @@ let stats engine =
   let workers_ready = Array.fold_left (fun acc w ->
     if Worker.is_ready w then acc + 1 else acc
   ) 0 engine.pool in
+  let total = Atomic.get engine.total_renders in
+  let errs = Atomic.get engine.errors in
   let cache_hit_rate =
-    if engine.total_renders > 0 then
-      float_of_int (engine.total_renders - engine.errors) /.
-      float_of_int engine.total_renders
+    if total > 0 then
+      float_of_int (total - errs) /. float_of_int total
     else 0.0
   in
   {
-    total_renders = engine.total_renders;
-    errors = engine.errors;
-    timeouts = engine.timeouts;
+    total_renders = total;
+    errors = errs;
+    timeouts = Atomic.get engine.timeouts;
     cache_size = Hashtbl.length engine.cache;
     cache_hit_rate;
     workers_ready;

--- a/lib/solid/worker.ml
+++ b/lib/solid/worker.ml
@@ -16,7 +16,7 @@ type state =
 type t = {
   mutable pid: int option;
   mutable state: state;
-  mutable request_count: int;
+  request_count: int Atomic.t;
   mutable last_health_check: float;
   mutable stdin: out_channel option;
   mutable stdout: in_channel option;
@@ -31,7 +31,7 @@ type t = {
 let create ~bundle ?(max_requests = 5000) ?(timeout = 10.0) () = {
   pid = None;
   state = Stopped;
-  request_count = 0;
+  request_count = Atomic.make 0;
   last_health_check = 0.0;
   stdin = None;
   stdout = None;
@@ -62,7 +62,7 @@ let start worker =
       worker.stdin <- Some (Unix.out_channel_of_descr stdin_write);
       worker.stdout <- Some (Unix.in_channel_of_descr stdout_read);
       worker.state <- Ready;
-      worker.request_count <- 0;
+      Atomic.set worker.request_count 0;
       worker.last_health_check <- Unix.time ();
       Ok ()
     with e ->
@@ -105,11 +105,11 @@ let send_request worker request =
        flush stdin;
 
        let response = input_line stdout in
-       worker.request_count <- worker.request_count + 1;
+       let count = Atomic.fetch_and_add worker.request_count 1 + 1 in
        worker.state <- Ready;
 
        (* Check if restart needed *)
-       if worker.request_count >= worker.max_requests then
+       if count >= worker.max_requests then
          ignore (restart worker);
 
        Ok response
@@ -157,12 +157,12 @@ let render worker ~url ?(props = `Assoc []) () =
 let get_state worker = worker.state
 
 (** Get request count *)
-let get_request_count worker = worker.request_count
+let get_request_count worker = Atomic.get worker.request_count
 
 (** Check if worker is ready *)
 let is_ready worker = worker.state = Ready
 
 (** Check if worker needs restart *)
 let needs_restart worker =
-  worker.request_count >= worker.max_requests ||
+  Atomic.get worker.request_count >= worker.max_requests ||
   worker.state = Unhealthy

--- a/lib/svelte/protocol.ml
+++ b/lib/svelte/protocol.ml
@@ -4,13 +4,12 @@
 
 (** {1 Protocol Types} *)
 
-(** Request ID counter *)
-let request_id = ref 0
+(** Request ID counter (atomic for concurrent safety) *)
+let request_id = Atomic.make 0
 
 (** Generate next request ID *)
 let next_id () =
-  incr request_id;
-  !request_id
+  Atomic.fetch_and_add request_id 1 + 1
 
 (** Render request *)
 type render_request = {

--- a/lib/svelte/ssr.ml
+++ b/lib/svelte/ssr.ml
@@ -34,11 +34,12 @@ type cache_entry = {
   expires_at: float;
 }
 
-(** Simple LRU cache *)
+(** Simple LRU cache (mutex-protected for concurrent access) *)
 type cache = {
   mutable entries: (string, cache_entry) Hashtbl.t;
   max_size: int;
   ttl: int;
+  mutex: Mutex.t;
 }
 
 (** Create cache *)
@@ -46,6 +47,7 @@ let create_cache ~max_size ~ttl = {
   entries = Hashtbl.create max_size;
   max_size;
   ttl;
+  mutex = Mutex.create ();
 }
 
 (** Cache key from request *)
@@ -55,34 +57,36 @@ let cache_key url props =
 
 (** Get from cache *)
 let cache_get cache key =
-  match Hashtbl.find_opt cache.entries key with
-  | Some entry when entry.expires_at > Unix.gettimeofday () ->
-    Some entry.response
-  | Some _ ->
-    Hashtbl.remove cache.entries key;
-    None
-  | None -> None
+  Mutex.protect cache.mutex (fun () ->
+    match Hashtbl.find_opt cache.entries key with
+    | Some entry when entry.expires_at > Unix.gettimeofday () ->
+      Some entry.response
+    | Some _ ->
+      Hashtbl.remove cache.entries key;
+      None
+    | None -> None)
 
 (** Put in cache *)
 let cache_put cache key response =
-  (* Simple eviction: if full, clear half *)
-  if Hashtbl.length cache.entries >= cache.max_size then begin
-    let to_remove = ref [] in
-    let count = ref 0 in
-    Hashtbl.iter (fun k _ ->
-      if !count < cache.max_size / 2 then begin
-        to_remove := k :: !to_remove;
-        incr count
-      end
-    ) cache.entries;
-    List.iter (Hashtbl.remove cache.entries) !to_remove
-  end;
+  Mutex.protect cache.mutex (fun () ->
+    (* Simple eviction: if full, clear half *)
+    if Hashtbl.length cache.entries >= cache.max_size then begin
+      let to_remove = ref [] in
+      let count = ref 0 in
+      Hashtbl.iter (fun k _ ->
+        if !count < cache.max_size / 2 then begin
+          to_remove := k :: !to_remove;
+          incr count
+        end
+      ) cache.entries;
+      List.iter (Hashtbl.remove cache.entries) !to_remove
+    end;
 
-  let entry = {
-    response;
-    expires_at = Unix.gettimeofday () +. float_of_int cache.ttl;
-  } in
-  Hashtbl.replace cache.entries key entry
+    let entry = {
+      response;
+      expires_at = Unix.gettimeofday () +. float_of_int cache.ttl;
+    } in
+    Hashtbl.replace cache.entries key entry)
 
 (** {1 Worker Pool} *)
 
@@ -91,10 +95,10 @@ type t = {
   config: config;
   workers: Worker.t array;
   cache: cache;
-  mutable next_worker: int;
-  mutable total_renders: int;
-  mutable cache_hits: int;
-  mutable errors: int;
+  next_worker: int Atomic.t;
+  total_renders: int Atomic.t;
+  cache_hits: int Atomic.t;
+  errors: int Atomic.t;
 }
 
 (** Create SSR engine *)
@@ -111,22 +115,22 @@ let create config =
     config;
     workers;
     cache;
-    next_worker = 0;
-    total_renders = 0;
-    cache_hits = 0;
-    errors = 0;
+    next_worker = Atomic.make 0;
+    total_renders = Atomic.make 0;
+    cache_hits = Atomic.make 0;
+    errors = Atomic.make 0;
   }
 
 (** Get next available worker (round-robin) *)
 let get_worker engine =
-  let start = engine.next_worker in
+  let start = Atomic.get engine.next_worker in
   let rec find_worker i =
     if i >= Array.length engine.workers then None
     else
       let idx = (start + i) mod Array.length engine.workers in
       let worker = engine.workers.(idx) in
       if Worker.is_healthy worker then begin
-        engine.next_worker <- (idx + 1) mod Array.length engine.workers;
+        Atomic.set engine.next_worker ((idx + 1) mod Array.length engine.workers);
         Some worker
       end
       else find_worker (i + 1)
@@ -137,7 +141,7 @@ let get_worker engine =
 
 (** Render URL to HTML *)
 let render engine ~url ?(props=`Assoc []) ?route_id ?(use_cache=true) () =
-  engine.total_renders <- engine.total_renders + 1;
+  ignore (Atomic.fetch_and_add engine.total_renders 1);
 
   (* Check cache first *)
   let key = cache_key url props in
@@ -147,13 +151,13 @@ let render engine ~url ?(props=`Assoc []) ?route_id ?(use_cache=true) () =
   in
   match cached with
   | Some response ->
-    engine.cache_hits <- engine.cache_hits + 1;
+    ignore (Atomic.fetch_and_add engine.cache_hits 1);
     Ok response
   | None ->
     (* Get worker and render *)
     match get_worker engine with
     | None ->
-      engine.errors <- engine.errors + 1;
+      ignore (Atomic.fetch_and_add engine.errors 1);
       Error "No healthy workers available"
     | Some worker ->
       match Worker.render worker ~url ~props ~route_id ~cookies:[] ~headers:[] () with
@@ -161,7 +165,7 @@ let render engine ~url ?(props=`Assoc []) ?route_id ?(use_cache=true) () =
         if use_cache then cache_put engine.cache key response;
         Ok response
       | Error msg ->
-        engine.errors <- engine.errors + 1;
+        ignore (Atomic.fetch_and_add engine.errors 1);
         Error msg
 
 (** Render with fallback *)
@@ -182,18 +186,20 @@ let preload engine urls =
 
 (** Invalidate cache entry *)
 let invalidate engine url =
-  let prefix = url ^ ":" in
-  let to_remove = ref [] in
-  Hashtbl.iter (fun k _ ->
-    if String.length k >= String.length prefix &&
-       String.sub k 0 (String.length prefix) = prefix then
-      to_remove := k :: !to_remove
-  ) engine.cache.entries;
-  List.iter (Hashtbl.remove engine.cache.entries) !to_remove
+  Mutex.protect engine.cache.mutex (fun () ->
+    let prefix = url ^ ":" in
+    let to_remove = ref [] in
+    Hashtbl.iter (fun k _ ->
+      if String.length k >= String.length prefix &&
+         String.sub k 0 (String.length prefix) = prefix then
+        to_remove := k :: !to_remove
+    ) engine.cache.entries;
+    List.iter (Hashtbl.remove engine.cache.entries) !to_remove)
 
 (** Clear entire cache *)
 let clear_cache engine =
-  Hashtbl.clear engine.cache.entries
+  Mutex.protect engine.cache.mutex (fun () ->
+    Hashtbl.clear engine.cache.entries)
 
 (** {1 Worker Management} *)
 
@@ -225,15 +231,17 @@ type stats = {
 
 (** Get engine statistics *)
 let get_stats (engine : t) =
+  let total = Atomic.get engine.total_renders in
+  let hits = Atomic.get engine.cache_hits in
   let hit_rate =
-    if engine.total_renders = 0 then 0.0
-    else float_of_int engine.cache_hits /. float_of_int engine.total_renders
+    if total = 0 then 0.0
+    else float_of_int hits /. float_of_int total
   in
   {
-    total_renders = engine.total_renders;
-    cache_hits = engine.cache_hits;
+    total_renders = total;
+    cache_hits = hits;
     cache_hit_rate = hit_rate;
-    errors = engine.errors;
+    errors = Atomic.get engine.errors;
     cache_size = Hashtbl.length engine.cache.entries;
     workers_ready = ready_workers engine;
     workers_total = Array.length engine.workers;

--- a/lib/svelte/streaming.ml
+++ b/lib/svelte/streaming.ml
@@ -13,11 +13,12 @@ type chunk =
   | Complete            (* Stream complete *)
   | Error of string     (* Error message *)
 
-(** Stream state *)
+(** Stream state (mutex-protected for concurrent access) *)
 type stream_state = {
   mutable chunks: chunk list;
   mutable completed: bool;
   mutable error: string option;
+  mutex: Mutex.t;
 }
 
 (** {1 Stream Creation} *)
@@ -27,23 +28,27 @@ let create () = {
   chunks = [];
   completed = false;
   error = None;
+  mutex = Mutex.create ();
 }
 
 (** Add chunk to stream *)
 let add_chunk stream chunk =
-  if not stream.completed then
-    stream.chunks <- stream.chunks @ [chunk]
+  Mutex.protect stream.mutex (fun () ->
+    if not stream.completed then
+      stream.chunks <- stream.chunks @ [chunk])
 
 (** Mark stream as complete *)
 let complete stream =
-  add_chunk stream Complete;
-  stream.completed <- true
+  Mutex.protect stream.mutex (fun () ->
+    stream.chunks <- stream.chunks @ [Complete];
+    stream.completed <- true)
 
 (** Mark stream as errored *)
 let fail stream msg =
-  stream.error <- Some msg;
-  add_chunk stream (Error msg);
-  stream.completed <- true
+  Mutex.protect stream.mutex (fun () ->
+    stream.error <- Some msg;
+    stream.chunks <- stream.chunks @ [Error msg];
+    stream.completed <- true)
 
 (** {1 Shell Generation} *)
 

--- a/lib/svelte/worker.ml
+++ b/lib/svelte/worker.ml
@@ -15,9 +15,9 @@ type status =
 type t = {
   mutable pid: int option;
   mutable status: status;
-  mutable request_count: int;
+  request_count: int Atomic.t;
   mutable last_request: float;
-  mutable error_count: int;
+  error_count: int Atomic.t;
   bundle_path: string;
   max_requests: int;
   memory_limit_mb: int;
@@ -29,9 +29,9 @@ type t = {
 let create ~bundle ~max_requests ~memory_limit_mb () = {
   pid = None;
   status = Ready;
-  request_count = 0;
+  request_count = Atomic.make 0;
   last_request = 0.0;
-  error_count = 0;
+  error_count = Atomic.make 0;
   bundle_path = bundle;
   max_requests;
   memory_limit_mb;
@@ -45,8 +45,8 @@ let is_healthy worker =
 
 (** Check if worker needs restart *)
 let needs_restart worker =
-  worker.request_count >= worker.max_requests ||
-  worker.error_count >= 5 ||
+  Atomic.get worker.request_count >= worker.max_requests ||
+  Atomic.get worker.error_count >= 5 ||
   worker.status = Crashed
 
 (** Get worker age in seconds *)
@@ -64,18 +64,18 @@ let mark_busy worker =
 (** Mark worker as ready *)
 let mark_ready worker =
   worker.status <- Ready;
-  worker.request_count <- worker.request_count + 1
+  ignore (Atomic.fetch_and_add worker.request_count 1)
 
 (** Mark worker as crashed *)
 let mark_crashed worker =
   worker.status <- Crashed;
-  worker.error_count <- worker.error_count + 1
+  ignore (Atomic.fetch_and_add worker.error_count 1)
 
 (** Reset worker state *)
 let reset worker =
   worker.status <- Ready;
-  worker.request_count <- 0;
-  worker.error_count <- 0
+  Atomic.set worker.request_count 0;
+  Atomic.set worker.error_count 0
 
 (** {1 Render Interface} *)
 
@@ -130,6 +130,7 @@ let start worker =
      node --expose-gc <bundle_path> *)
   worker.pid <- Some (Unix.getpid ());  (* Placeholder *)
   worker.status <- Ready;
+  Atomic.set worker.request_count 0;
   Ok ()
 
 (** Stop worker process *)
@@ -156,8 +157,8 @@ type stats = {
 
 (** Get worker stats *)
 let stats worker = {
-  requests = worker.request_count;
-  errors = worker.error_count;
+  requests = Atomic.get worker.request_count;
+  errors = Atomic.get worker.error_count;
   uptime = age worker;
   status = worker.status;
 }

--- a/lib/trpc/subscription.ml
+++ b/lib/trpc/subscription.ml
@@ -88,28 +88,36 @@ module Registry = struct
 
   type t = {
     mutable subscriptions: (sub_id * cancel_fn) list;
+    mutex: Mutex.t;
   }
 
-  let create () = { subscriptions = [] }
+  let create () = { subscriptions = []; mutex = Mutex.create () }
 
   let add t ~id ~cancel =
-    t.subscriptions <- (id, cancel) :: t.subscriptions
+    Mutex.protect t.mutex (fun () ->
+      t.subscriptions <- (id, cancel) :: t.subscriptions)
 
   let remove t id =
-    match List.assoc_opt id t.subscriptions with
-    | Some cancel ->
-      cancel ();
-      t.subscriptions <- List.filter (fun (i, _) -> i <> id) t.subscriptions;
-      true
-    | None -> false
+    Mutex.protect t.mutex (fun () ->
+      match List.assoc_opt id t.subscriptions with
+      | Some cancel ->
+        cancel ();
+        t.subscriptions <- List.filter (fun (i, _) -> i <> id) t.subscriptions;
+        true
+      | None -> false)
 
   let cancel_all t =
-    List.iter (fun (_, cancel) -> cancel ()) t.subscriptions;
-    t.subscriptions <- []
+    Mutex.protect t.mutex (fun () ->
+      List.iter (fun (_, cancel) -> cancel ()) t.subscriptions;
+      t.subscriptions <- [])
 
-  let count t = List.length t.subscriptions
+  let count t =
+    Mutex.protect t.mutex (fun () ->
+      List.length t.subscriptions)
 
-  let has t id = List.mem_assoc id t.subscriptions
+  let has t id =
+    Mutex.protect t.mutex (fun () ->
+      List.mem_assoc id t.subscriptions)
 end
 
 (** {1 SSE Helpers} *)

--- a/lib/vue/ssr.ml
+++ b/lib/vue/ssr.ml
@@ -78,6 +78,7 @@ let empty_stats = {
 type t = {
   config: config;
   mutable stats: stats;
+  stats_mutex: Mutex.t;
   mutable cache: (string, render_result * float) Hashtbl.t;
   mutable running: bool;
 }
@@ -86,6 +87,7 @@ type t = {
 let create config = {
   config;
   stats = empty_stats;
+  stats_mutex = Mutex.create ();
   cache = Hashtbl.create 256;
   running = true;
 }
@@ -132,10 +134,11 @@ let render t ~url ?(headers=[]) ?(payload=None) () =
     (* Check cache first *)
     match check_cache t url with
     | Some cached ->
-      t.stats <- { t.stats with
-        total_renders = t.stats.total_renders + 1;
-        cache_hits = t.stats.cache_hits + 1;
-      };
+      Mutex.protect t.stats_mutex (fun () ->
+        t.stats <- { t.stats with
+          total_renders = t.stats.total_renders + 1;
+          cache_hits = t.stats.cache_hits + 1;
+        });
       Ok { cached with cache_hit = true }
     | None ->
       let start_time = Unix.gettimeofday () in
@@ -163,13 +166,14 @@ let render t ~url ?(headers=[]) ?(payload=None) () =
       } in
 
       (* Update stats *)
-      let total = t.stats.total_renders + 1 in
-      let total_time = t.stats.avg_render_time_ms *. Float.of_int t.stats.total_renders +. render_time_ms in
-      t.stats <- { t.stats with
-        total_renders = total;
-        cache_misses = t.stats.cache_misses + 1;
-        avg_render_time_ms = total_time /. Float.of_int total;
-      };
+      Mutex.protect t.stats_mutex (fun () ->
+        let total = t.stats.total_renders + 1 in
+        let total_time = t.stats.avg_render_time_ms *. Float.of_int t.stats.total_renders +. render_time_ms in
+        t.stats <- { t.stats with
+          total_renders = total;
+          cache_misses = t.stats.cache_misses + 1;
+          avg_render_time_ms = total_time /. Float.of_int total;
+        });
 
       (* Store in cache *)
       store_cache t url result;
@@ -182,7 +186,8 @@ let render_with_fallback t ~url ~fallback =
   match render t ~url () with
   | Ok result -> result.html
   | Error _ ->
-    t.stats <- { t.stats with errors = t.stats.errors + 1 };
+    Mutex.protect t.stats_mutex (fun () ->
+      t.stats <- { t.stats with errors = t.stats.errors + 1 });
     fallback
 
 (** {1 Prerendering} *)

--- a/lib/vue/streaming.ml
+++ b/lib/vue/streaming.ml
@@ -131,7 +131,7 @@ let streaming_headers ?(content_type="text/html; charset=utf-8") () = [
 
 (** {1 Stream State Machine} *)
 
-(** Stream context *)
+(** Stream context (mutex-protected for concurrent access) *)
 type context = {
   config: config;
   mutable state: state;
@@ -139,6 +139,7 @@ type context = {
   mutable bytes_sent: int;
   mutable suspense_pending: string list;
   mutable islands_pending: string list;
+  mutex: Mutex.t;
 }
 
 (** Create stream context *)
@@ -149,38 +150,46 @@ let create_context ?(config=default_config) () = {
   bytes_sent = 0;
   suspense_pending = [];
   islands_pending = [];
+  mutex = Mutex.create ();
 }
 
 (** Start streaming *)
 let start ctx =
-  ctx.state <- Streaming
+  Mutex.protect ctx.mutex (fun () ->
+    ctx.state <- Streaming)
 
 (** Mark suspense as pending *)
 let add_suspense ctx id =
-  ctx.suspense_pending <- id :: ctx.suspense_pending
+  Mutex.protect ctx.mutex (fun () ->
+    ctx.suspense_pending <- id :: ctx.suspense_pending)
 
 (** Mark island as pending *)
 let add_island ctx id =
-  ctx.islands_pending <- id :: ctx.islands_pending
+  Mutex.protect ctx.mutex (fun () ->
+    ctx.islands_pending <- id :: ctx.islands_pending)
 
 (** Resolve suspense *)
 let resolve_suspense ctx id =
-  ctx.suspense_pending <- List.filter (fun i -> i <> id) ctx.suspense_pending
+  Mutex.protect ctx.mutex (fun () ->
+    ctx.suspense_pending <- List.filter (fun i -> i <> id) ctx.suspense_pending)
 
 (** Resolve island *)
 let resolve_island ctx id =
-  ctx.islands_pending <- List.filter (fun i -> i <> id) ctx.islands_pending
+  Mutex.protect ctx.mutex (fun () ->
+    ctx.islands_pending <- List.filter (fun i -> i <> id) ctx.islands_pending)
 
 (** Send chunk *)
 let send_chunk ctx chunk =
-  ctx.chunks_sent <- ctx.chunks_sent + 1;
-  let html = render_chunk chunk in
-  ctx.bytes_sent <- ctx.bytes_sent + String.length html;
-  encode_chunked html
+  Mutex.protect ctx.mutex (fun () ->
+    ctx.chunks_sent <- ctx.chunks_sent + 1;
+    let html = render_chunk chunk in
+    ctx.bytes_sent <- ctx.bytes_sent + String.length html;
+    encode_chunked html)
 
 (** Finish streaming *)
 let finish ctx =
-  ctx.state <- Complete;
+  Mutex.protect ctx.mutex (fun () ->
+    ctx.state <- Complete);
   encode_chunked_end ()
 
 (** Check if complete *)


### PR DESCRIPTION
## Summary
Cross-project Eio concurrency 감사에서 발견된 13건의 data race 수정.

### Category A: ref → Atomic.t
- `svelte/protocol.ml` — `request_id` ref → `Atomic.t`

### Category B: mutable counters → Atomic.t (8건)
- `svelte/ssr.ml`, `svelte/worker.ml`, `lit/ssr.ml`, `solid/ssr.ml`, `solid/worker.ml` — render/error/timeout counters
- `parallel.ml` — `Pool.active` flag

### Category C: shared state → Stdlib.Mutex (4건)
- `svelte/ssr.ml` — cache entries Hashtbl
- `svelte/streaming.ml` — stream_state
- `vue/ssr.ml` — stats record
- `vue/streaming.ml` — streaming context
- `trpc/subscription.ml` — subscription registry

Stdlib.Mutex 선택 이유: 기존 테스트가 Eio event loop 없이 실행되므로 Eio.Mutex 대신 OCaml 5 Stdlib.Mutex 사용.

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)