### PR TITLE
test: add dedicated tests for 7 core modules

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -106,3 +106,31 @@
  (name test_no_shell_node_worker)
  (deps ../lib/react/node_worker.ml)
  (action (run %{exe:test_no_shell_node_worker.exe} %{dep:../lib/react/node_worker.ml})))
+
+(test
+ (name test_cache)
+ (libraries kirin alcotest eio_main unix))
+
+(test
+ (name test_pool)
+ (libraries kirin alcotest eio_main unix))
+
+(test
+ (name test_websocket)
+ (libraries kirin alcotest))
+
+(test
+ (name test_sse)
+ (libraries kirin alcotest eio eio_main))
+
+(test
+ (name test_router)
+ (libraries kirin alcotest eio eio_main))
+
+(test
+ (name test_middleware)
+ (libraries kirin alcotest eio eio_main unix))
+
+(test
+ (name test_cookie)
+ (libraries kirin alcotest eio eio_main))

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -1,0 +1,315 @@
+(** Cache module tests.
+    Uses Eio_main.run because Cache relies on Eio.Mutex. *)
+
+open Alcotest
+
+(* -- creation and basic ops ---------------------------------------- *)
+
+let test_create_default () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create () in
+  check int "size 0" 0 (Kirin.Cache.size cache);
+  let s = Kirin.Cache.stats cache in
+  check int "max_size" 1000 s.Kirin.Cache.max_size;
+  check int "hits" 0 s.Kirin.Cache.hits;
+  check int "misses" 0 s.Kirin.Cache.misses
+
+let test_create_custom () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:5 ~default_ttl:10.0 ~cleanup_interval:30.0 () in
+  let s = Kirin.Cache.stats cache in
+  check int "custom max_size" 5 s.Kirin.Cache.max_size
+
+let test_set_and_get () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "key1" "value1";
+  let result = Kirin.Cache.get cache "key1" in
+  check (option string) "found" (Some "value1") result
+
+let test_get_missing () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  let result = Kirin.Cache.get cache "missing" in
+  check (option string) "not found" None result
+
+let test_set_overwrites () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "k" "v1";
+  Kirin.Cache.set cache "k" "v2";
+  check (option string) "overwritten" (Some "v2") (Kirin.Cache.get cache "k");
+  check int "size stays 1" 1 (Kirin.Cache.size cache)
+
+let test_remove () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "k" "v";
+  let removed = Kirin.Cache.remove cache "k" in
+  check bool "removed true" true removed;
+  check (option string) "gone" None (Kirin.Cache.get cache "k");
+  let not_found = Kirin.Cache.remove cache "k" in
+  check bool "remove nonexistent" false not_found
+
+let test_mem () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "k" "v";
+  check bool "mem existing" true (Kirin.Cache.mem cache "k");
+  check bool "mem missing" false (Kirin.Cache.mem cache "other")
+
+let basic_tests = [
+  test_case "create default" `Quick test_create_default;
+  test_case "create custom" `Quick test_create_custom;
+  test_case "set and get" `Quick test_set_and_get;
+  test_case "get missing" `Quick test_get_missing;
+  test_case "set overwrites" `Quick test_set_overwrites;
+  test_case "remove" `Quick test_remove;
+  test_case "mem" `Quick test_mem;
+]
+
+(* -- TTL expiry ---------------------------------------------------- *)
+
+let test_ttl_expiry () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set ~ttl:0.0 cache "short" "val";
+  Unix.sleepf 0.01;
+  let result = Kirin.Cache.get cache "short" in
+  check (option string) "expired" None result
+
+let test_default_ttl () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 ~default_ttl:0.0 () in
+  Kirin.Cache.set cache "k" "v";
+  Unix.sleepf 0.01;
+  let result = Kirin.Cache.get cache "k" in
+  check (option string) "default ttl expired" None result
+
+let test_no_ttl_never_expires () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "forever" "here";
+  check (option string) "still here" (Some "here") (Kirin.Cache.get cache "forever")
+
+let test_per_entry_ttl_overrides_default () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 ~default_ttl:3600.0 () in
+  Kirin.Cache.set ~ttl:0.0 cache "short" "val";
+  Unix.sleepf 0.01;
+  check (option string) "per-entry ttl expired" None (Kirin.Cache.get cache "short")
+
+let ttl_tests = [
+  test_case "ttl expiry" `Quick test_ttl_expiry;
+  test_case "default ttl" `Quick test_default_ttl;
+  test_case "no ttl never expires" `Quick test_no_ttl_never_expires;
+  test_case "per-entry ttl overrides default" `Quick test_per_entry_ttl_overrides_default;
+]
+
+(* -- LRU eviction -------------------------------------------------- *)
+
+let test_lru_eviction () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:3 () in
+  Kirin.Cache.set cache "a" "1";
+  Kirin.Cache.set cache "b" "2";
+  Kirin.Cache.set cache "c" "3";
+  ignore (Kirin.Cache.get cache "a");
+  Kirin.Cache.set cache "d" "4";
+  check int "size still 3" 3 (Kirin.Cache.size cache);
+  check (option string) "a survived" (Some "1") (Kirin.Cache.get cache "a");
+  check (option string) "b evicted" None (Kirin.Cache.get cache "b");
+  check (option string) "c survived" (Some "3") (Kirin.Cache.get cache "c");
+  check (option string) "d present" (Some "4") (Kirin.Cache.get cache "d")
+
+let test_eviction_stats () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:2 () in
+  Kirin.Cache.set cache "a" "1";
+  Kirin.Cache.set cache "b" "2";
+  Kirin.Cache.set cache "c" "3";
+  let s = Kirin.Cache.stats cache in
+  check int "evictions" 1 s.Kirin.Cache.evictions
+
+let lru_tests = [
+  test_case "LRU eviction" `Quick test_lru_eviction;
+  test_case "eviction stats" `Quick test_eviction_stats;
+]
+
+(* -- statistics ---------------------------------------------------- *)
+
+let test_hit_miss_stats () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "k" "v";
+  ignore (Kirin.Cache.get cache "k");
+  ignore (Kirin.Cache.get cache "k");
+  ignore (Kirin.Cache.get cache "nope");
+  let s = Kirin.Cache.stats cache in
+  check int "hits" 2 s.Kirin.Cache.hits;
+  check int "misses" 1 s.Kirin.Cache.misses
+
+let test_hit_rate () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  check (float 0.001) "no ops = 0.0" 0.0 (Kirin.Cache.hit_rate cache);
+  Kirin.Cache.set cache "k" "v";
+  ignore (Kirin.Cache.get cache "k");
+  ignore (Kirin.Cache.get cache "miss");
+  let rate = Kirin.Cache.hit_rate cache in
+  check (float 0.001) "hit rate 0.5" 0.5 rate
+
+let stats_tests = [
+  test_case "hit/miss counters" `Quick test_hit_miss_stats;
+  test_case "hit_rate" `Quick test_hit_rate;
+]
+
+(* -- clear / cleanup / keys / iteration ---------------------------- *)
+
+let test_clear () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "a" "1";
+  Kirin.Cache.set cache "b" "2";
+  Kirin.Cache.clear cache;
+  check int "cleared size" 0 (Kirin.Cache.size cache);
+  check (option string) "a gone" None (Kirin.Cache.get cache "a")
+
+let test_cleanup () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set ~ttl:0.0 cache "expired1" "v";
+  Kirin.Cache.set ~ttl:0.0 cache "expired2" "v";
+  Kirin.Cache.set cache "alive" "v";
+  Unix.sleepf 0.01;
+  let removed = Kirin.Cache.cleanup cache in
+  check int "2 cleaned" 2 removed;
+  check int "1 remaining" 1 (Kirin.Cache.size cache)
+
+let test_keys () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "x" "1";
+  Kirin.Cache.set cache "y" "2";
+  let ks = Kirin.Cache.keys cache |> List.sort String.compare in
+  check (list string) "keys" ["x"; "y"] ks
+
+let test_iter () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "a" 1;
+  Kirin.Cache.set cache "b" 2;
+  let sum = ref 0 in
+  Kirin.Cache.iter (fun _k v -> sum := !sum + v) cache;
+  check int "sum" 3 !sum
+
+let test_fold () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "a" 10;
+  Kirin.Cache.set cache "b" 20;
+  let total = Kirin.Cache.fold (fun _k v acc -> acc + v) cache 0 in
+  check int "fold sum" 30 total
+
+let bulk_tests = [
+  test_case "clear" `Quick test_clear;
+  test_case "cleanup expired" `Quick test_cleanup;
+  test_case "keys" `Quick test_keys;
+  test_case "iter" `Quick test_iter;
+  test_case "fold" `Quick test_fold;
+]
+
+(* -- get_or_set ---------------------------------------------------- *)
+
+let test_get_or_set_miss () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  let called = ref false in
+  let v = Kirin.Cache.get_or_set cache "k" (fun () -> called := true; "computed") in
+  check string "computed" "computed" v;
+  check bool "compute called" true !called
+
+let test_get_or_set_hit () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set cache "k" "cached";
+  let called = ref false in
+  let v = Kirin.Cache.get_or_set cache "k" (fun () -> called := true; "new") in
+  check string "cached" "cached" v;
+  check bool "compute not called" false !called
+
+let get_or_set_tests = [
+  test_case "miss computes" `Quick test_get_or_set_miss;
+  test_case "hit skips compute" `Quick test_get_or_set_hit;
+]
+
+(* -- memoize / make_key -------------------------------------------- *)
+
+let test_memoize () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  let call_count = ref 0 in
+  let expensive x =
+    incr call_count;
+    x * 2
+  in
+  let memo = Kirin.Cache.memoize cache ~key_fn:string_of_int expensive in
+  let r1 = memo 5 in
+  let r2 = memo 5 in
+  check int "first call" 10 r1;
+  check int "second call cached" 10 r2;
+  check int "compute called once" 1 !call_count
+
+let test_make_key () =
+  check string "joined" "a:b:c" (Kirin.Cache.make_key ["a"; "b"; "c"]);
+  check string "single" "x" (Kirin.Cache.make_key ["x"]);
+  check string "empty" "" (Kirin.Cache.make_key [])
+
+let utility_tests = [
+  test_case "memoize" `Quick test_memoize;
+  test_case "make_key" `Quick test_make_key;
+]
+
+(* -- StringCache module -------------------------------------------- *)
+
+let test_string_cache () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.StringCache.create ~max_size:5 () in
+  Kirin.Cache.StringCache.set cache "hello" 42;
+  check (option int) "found" (Some 42) (Kirin.Cache.StringCache.get cache "hello");
+  check int "size" 1 (Kirin.Cache.StringCache.size cache);
+  check bool "mem" true (Kirin.Cache.StringCache.mem cache "hello");
+  ignore (Kirin.Cache.StringCache.remove cache "hello");
+  check bool "removed" false (Kirin.Cache.StringCache.mem cache "hello");
+  Kirin.Cache.StringCache.set cache "a" 1;
+  Kirin.Cache.StringCache.clear cache;
+  check int "cleared" 0 (Kirin.Cache.StringCache.size cache)
+
+(* -- IntCache module ----------------------------------------------- *)
+
+let test_int_cache () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.IntCache.create ~max_size:5 () in
+  Kirin.Cache.IntCache.set cache 1 "one";
+  Kirin.Cache.IntCache.set cache 2 "two";
+  check (option string) "int key" (Some "one") (Kirin.Cache.IntCache.get cache 1);
+  check int "size" 2 (Kirin.Cache.IntCache.size cache)
+
+let specialized_tests = [
+  test_case "StringCache" `Quick test_string_cache;
+  test_case "IntCache" `Quick test_int_cache;
+]
+
+(* -- run ----------------------------------------------------------- *)
+
+let () =
+  Alcotest.run "Cache" [
+    ("basic", basic_tests);
+    ("ttl", ttl_tests);
+    ("lru", lru_tests);
+    ("statistics", stats_tests);
+    ("bulk", bulk_tests);
+    ("get_or_set", get_or_set_tests);
+    ("utility", utility_tests);
+    ("specialized", specialized_tests);
+  ]

--- a/test/test_cookie.ml
+++ b/test/test_cookie.ml
@@ -1,0 +1,186 @@
+(** Cookie module tests *)
+
+open Alcotest
+
+let make_req ?(headers = []) path =
+  let raw = Http.Request.make ~meth:`GET ~headers:(Http.Header.of_list headers) path in
+  let body_source = Eio.Flow.string_source "" |> Eio.Buf_read.of_flow ~max_size:1024 in
+  Kirin.Request.make ~raw ~body_source
+
+(** Check if [sub] is a substring of [s]. *)
+let contains_substring s sub =
+  let slen = String.length s in
+  let sublen = String.length sub in
+  if sublen > slen then false
+  else
+    let rec check i =
+      if i > slen - sublen then false
+      else if String.sub s i sublen = sub then true
+      else check (i + 1)
+    in
+    check 0
+
+(* -- parse_cookies ------------------------------------------------- *)
+
+let test_parse_single () =
+  let cookies = Kirin.Cookie.parse_cookies "name=value" in
+  check int "one cookie" 1 (List.length cookies);
+  check (option string) "name" (Some "value") (List.assoc_opt "name" cookies)
+
+let test_parse_multiple () =
+  let cookies = Kirin.Cookie.parse_cookies "a=1; b=2; c=3" in
+  check int "three cookies" 3 (List.length cookies);
+  check (option string) "a" (Some "1") (List.assoc_opt "a" cookies);
+  check (option string) "b" (Some "2") (List.assoc_opt "b" cookies);
+  check (option string) "c" (Some "3") (List.assoc_opt "c" cookies)
+
+let test_parse_with_spaces () =
+  let cookies = Kirin.Cookie.parse_cookies "  foo = bar ; baz = qux  " in
+  check (option string) "foo" (Some "bar") (List.assoc_opt "foo" cookies);
+  check (option string) "baz" (Some "qux") (List.assoc_opt "baz" cookies)
+
+let test_parse_empty () =
+  let cookies = Kirin.Cookie.parse_cookies "" in
+  check int "no cookies" 0 (List.length cookies)
+
+let parse_tests = [
+  test_case "single cookie" `Quick test_parse_single;
+  test_case "multiple cookies" `Quick test_parse_multiple;
+  test_case "cookies with spaces" `Quick test_parse_with_spaces;
+  test_case "empty header" `Quick test_parse_empty;
+]
+
+(* -- get from request ---------------------------------------------- *)
+
+let test_get_cookie_from_req () =
+  let req = make_req ~headers:[("cookie", "session=abc123; lang=en")] "/" in
+  check (option string) "session" (Some "abc123") (Kirin.Cookie.get "session" req);
+  check (option string) "lang" (Some "en") (Kirin.Cookie.get "lang" req);
+  check (option string) "missing" None (Kirin.Cookie.get "nope" req)
+
+let test_get_all () =
+  let req = make_req ~headers:[("cookie", "x=1; y=2")] "/" in
+  let all = Kirin.Cookie.get_all req in
+  check int "count" 2 (List.length all)
+
+let test_get_no_cookie_header () =
+  let req = make_req "/" in
+  check (option string) "no header" None (Kirin.Cookie.get "anything" req)
+
+let get_tests = [
+  test_case "get specific cookie" `Quick test_get_cookie_from_req;
+  test_case "get all cookies" `Quick test_get_all;
+  test_case "no cookie header" `Quick test_get_no_cookie_header;
+]
+
+(* -- build_set_cookie / serialization ------------------------------ *)
+
+let test_build_minimal () =
+  let attrs = { Kirin.Cookie.default_attributes with
+    path = None; http_only = false; same_site = None } in
+  let s = Kirin.Cookie.build_set_cookie "k" "v" attrs in
+  check bool "starts with k=" true (contains_substring s "k=")
+
+let test_build_all_attributes () =
+  let attrs = {
+    Kirin.Cookie.max_age = Some 3600;
+    expires = Some "Thu, 01 Jan 2026 00:00:00 GMT";
+    domain = Some ".example.com";
+    path = Some "/app";
+    secure = true;
+    http_only = true;
+    same_site = Some `Strict;
+  } in
+  let s = Kirin.Cookie.build_set_cookie "token" "xyz" attrs in
+  check bool "has Max-Age" true (contains_substring s "Max-Age=3600");
+  check bool "has Expires" true (contains_substring s "Expires=");
+  check bool "has Domain" true (contains_substring s "Domain=.example.com");
+  check bool "has Path" true (contains_substring s "Path=/app");
+  check bool "has Secure" true (contains_substring s "Secure");
+  check bool "has HttpOnly" true (contains_substring s "HttpOnly");
+  check bool "has SameSite=Strict" true (contains_substring s "SameSite=Strict")
+
+let test_build_samesite_lax () =
+  let attrs = { Kirin.Cookie.default_attributes with same_site = Some `Lax } in
+  let s = Kirin.Cookie.build_set_cookie "k" "v" attrs in
+  check bool "SameSite=Lax" true (contains_substring s "SameSite=Lax")
+
+let test_build_samesite_none () =
+  let attrs = { Kirin.Cookie.default_attributes with same_site = Some `None } in
+  let s = Kirin.Cookie.build_set_cookie "k" "v" attrs in
+  check bool "SameSite=None" true (contains_substring s "SameSite=None")
+
+let build_tests = [
+  test_case "minimal cookie" `Quick test_build_minimal;
+  test_case "all attributes" `Quick test_build_all_attributes;
+  test_case "samesite lax" `Quick test_build_samesite_lax;
+  test_case "samesite none" `Quick test_build_samesite_none;
+]
+
+(* -- set / delete on response -------------------------------------- *)
+
+let test_set_cookie_on_response () =
+  let resp = Kirin.Response.text "ok" in
+  let resp = Kirin.Cookie.set "sid" "abc" resp in
+  let h = Kirin.Response.header "set-cookie" resp in
+  check bool "has set-cookie" true (Option.is_some h);
+  let v = Option.get h in
+  check bool "contains sid=" true (contains_substring v "sid=")
+
+let test_delete_cookie () =
+  let resp = Kirin.Response.text "ok" in
+  let resp = Kirin.Cookie.delete "sid" resp in
+  let h = Kirin.Response.header "set-cookie" resp in
+  check bool "has set-cookie" true (Option.is_some h);
+  let v = Option.get h in
+  check bool "Max-Age=0" true (contains_substring v "Max-Age=0")
+
+let set_tests = [
+  test_case "set cookie on response" `Quick test_set_cookie_on_response;
+  test_case "delete cookie" `Quick test_delete_cookie;
+]
+
+(* -- signed cookies ------------------------------------------------ *)
+
+let test_set_secret_too_short () =
+  check_raises "short secret" (Failure "Cookie secret key must be at least 32 characters")
+    (fun () -> Kirin.Cookie.set_secret "short")
+
+let test_sign_and_verify () =
+  Kirin.Cookie.set_secret "this-is-a-very-long-secret-key-for-testing-purposes";
+  let sig_value = Kirin.Cookie.sign "hello" in
+  check bool "signature is non-empty" true (String.length sig_value > 0);
+  let signed = "hello." ^ sig_value in
+  let result = Kirin.Cookie.verify signed in
+  check (option string) "verified" (Some "hello") result
+
+let test_verify_tampered () =
+  Kirin.Cookie.set_secret "this-is-a-very-long-secret-key-for-testing-purposes";
+  let sig_value = Kirin.Cookie.sign "hello" in
+  let tampered = "tampered." ^ sig_value in
+  let result = Kirin.Cookie.verify tampered in
+  check (option string) "tampered fails" None result
+
+let test_verify_no_dot () =
+  Kirin.Cookie.set_secret "this-is-a-very-long-secret-key-for-testing-purposes";
+  let result = Kirin.Cookie.verify "noseparator" in
+  check (option string) "no dot fails" None result
+
+let signed_tests = [
+  test_case "secret too short" `Quick test_set_secret_too_short;
+  test_case "sign and verify" `Quick test_sign_and_verify;
+  test_case "tampered value" `Quick test_verify_tampered;
+  test_case "no separator" `Quick test_verify_no_dot;
+]
+
+(* -- run ----------------------------------------------------------- *)
+
+let () =
+  Eio_main.run @@ fun _env ->
+  Alcotest.run "Cookie" [
+    ("parse", parse_tests);
+    ("get", get_tests);
+    ("build_set_cookie", build_tests);
+    ("set/delete", set_tests);
+    ("signed", signed_tests);
+  ]

--- a/test/test_middleware.ml
+++ b/test/test_middleware.ml
@@ -1,0 +1,185 @@
+(** Middleware module tests *)
+
+open Alcotest
+
+let body_to_string = function
+  | Kirin.Response.String s -> s
+  | Kirin.Response.Stream _ -> "<stream>"
+  | Kirin.Response.Producer _ -> "<producer>"
+
+let make_req ?(meth = `GET) ?(headers = []) path =
+  let raw = Http.Request.make ~meth ~headers:(Http.Header.of_list headers) path in
+  let body_source = Eio.Flow.string_source "" |> Eio.Buf_read.of_flow ~max_size:1024 in
+  Kirin.Request.make ~raw ~body_source
+
+let base_handler _req = Kirin.Response.text "base"
+
+(* -- identity middleware ------------------------------------------- *)
+
+let test_id () =
+  let handler = Kirin.Middleware.apply Kirin.Middleware.id base_handler in
+  let resp = handler (make_req "/") in
+  check string "passthrough" "base" (body_to_string (Kirin.Response.body resp))
+
+(* -- compose ------------------------------------------------------- *)
+
+let test_compose_order () =
+  let m1 : Kirin.Middleware.t = fun handler req ->
+    let resp = handler req in
+    Kirin.Response.with_header "x-m1" "1" resp
+  in
+  let m2 : Kirin.Middleware.t = fun handler req ->
+    let resp = handler req in
+    Kirin.Response.with_header "x-m2" "2" resp
+  in
+  let composed = Kirin.Middleware.compose m1 m2 in
+  let handler = Kirin.Middleware.apply composed base_handler in
+  let resp = handler (make_req "/") in
+  check (option string) "m1 applied" (Some "1") (Kirin.Response.header "x-m1" resp);
+  check (option string) "m2 applied" (Some "2") (Kirin.Response.header "x-m2" resp)
+
+let test_infix_compose () =
+  let m1 : Kirin.Middleware.t = fun handler req ->
+    let resp = handler req in
+    Kirin.Response.with_header "x-a" "a" resp
+  in
+  let m2 : Kirin.Middleware.t = fun handler req ->
+    let resp = handler req in
+    Kirin.Response.with_header "x-b" "b" resp
+  in
+  let composed = Kirin.Middleware.(m1 >> m2) in
+  let handler = Kirin.Middleware.apply composed base_handler in
+  let resp = handler (make_req "/") in
+  check (option string) "a" (Some "a") (Kirin.Response.header "x-a" resp);
+  check (option string) "b" (Some "b") (Kirin.Response.header "x-b" resp)
+
+(* -- pipeline ------------------------------------------------------ *)
+
+let test_pipeline_empty () =
+  let handler = Kirin.Middleware.apply (Kirin.Middleware.pipeline []) base_handler in
+  let resp = handler (make_req "/") in
+  check string "empty pipeline" "base" (body_to_string (Kirin.Response.body resp))
+
+let test_pipeline_multiple () =
+  let append_header name value : Kirin.Middleware.t = fun handler req ->
+    let resp = handler req in
+    Kirin.Response.with_header name value resp
+  in
+  let pipe = Kirin.Middleware.pipeline [
+    append_header "x-first" "1";
+    append_header "x-second" "2";
+    append_header "x-third" "3";
+  ] in
+  let handler = Kirin.Middleware.apply pipe base_handler in
+  let resp = handler (make_req "/") in
+  check (option string) "first" (Some "1") (Kirin.Response.header "x-first" resp);
+  check (option string) "second" (Some "2") (Kirin.Response.header "x-second" resp);
+  check (option string) "third" (Some "3") (Kirin.Response.header "x-third" resp)
+
+(* -- short circuit (early return) ---------------------------------- *)
+
+let test_short_circuit () =
+  let blocker : Kirin.Middleware.t = fun _handler _req ->
+    Kirin.Response.text ~status:`Forbidden "blocked"
+  in
+  let handler = Kirin.Middleware.apply blocker base_handler in
+  let resp = handler (make_req "/") in
+  check int "403 status" 403 (Kirin.Response.status_code resp);
+  check string "blocked body" "blocked" (body_to_string (Kirin.Response.body resp))
+
+(* -- catch --------------------------------------------------------- *)
+
+let test_catch_handles_exception () =
+  let failing_handler _req = failwith "boom" in
+  let error_handler _exn _req = Kirin.Response.text ~status:`Internal_server_error "caught" in
+  let handler = Kirin.Middleware.apply (Kirin.Middleware.catch error_handler) failing_handler in
+  let resp = handler (make_req "/") in
+  check int "500 status" 500 (Kirin.Response.status_code resp);
+  check string "caught body" "caught" (body_to_string (Kirin.Response.body resp))
+
+let test_catch_default () =
+  let failing_handler _req = failwith "unexpected" in
+  let handler = Kirin.Middleware.apply Kirin.Middleware.catch_default failing_handler in
+  let resp = handler (make_req "/") in
+  check int "500 status" 500 (Kirin.Response.status_code resp)
+
+let test_catch_passthrough_on_success () =
+  let handler = Kirin.Middleware.apply Kirin.Middleware.catch_default base_handler in
+  let resp = handler (make_req "/") in
+  check string "normal response" "base" (body_to_string (Kirin.Response.body resp))
+
+(* -- with_headers -------------------------------------------------- *)
+
+let test_with_headers () =
+  let mw = Kirin.Middleware.with_headers [("x-custom", "val"); ("x-other", "o")] in
+  let handler = Kirin.Middleware.apply mw base_handler in
+  let resp = handler (make_req "/") in
+  check (option string) "custom" (Some "val") (Kirin.Response.header "x-custom" resp);
+  check (option string) "other" (Some "o") (Kirin.Response.header "x-other" resp)
+
+(* -- timing -------------------------------------------------------- *)
+
+let test_timing_adds_header () =
+  let handler = Kirin.Middleware.apply Kirin.Middleware.timing base_handler in
+  let resp = handler (make_req "/") in
+  let h = Kirin.Response.header "X-Response-Time" resp in
+  check bool "has timing header" true (Option.is_some h)
+
+(* -- cors ---------------------------------------------------------- *)
+
+let test_cors_default_preflight () =
+  let handler = Kirin.Middleware.apply (Kirin.Middleware.cors ()) base_handler in
+  let req = make_req ~meth:`OPTIONS ~headers:[("origin", "http://example.com")] "/" in
+  let resp = handler req in
+  check int "204 for preflight" 204 (Kirin.Response.status_code resp);
+  check (option string) "allow origin" (Some "http://example.com")
+    (Kirin.Response.header "Access-Control-Allow-Origin" resp)
+
+let test_cors_normal_request () =
+  let handler = Kirin.Middleware.apply (Kirin.Middleware.cors ()) base_handler in
+  let req = make_req ~headers:[("origin", "http://example.com")] "/" in
+  let resp = handler req in
+  check int "200 for normal" 200 (Kirin.Response.status_code resp);
+  check (option string) "allow origin" (Some "http://example.com")
+    (Kirin.Response.header "Access-Control-Allow-Origin" resp)
+
+let test_cors_restricted_origins () =
+  let config = { Kirin.Middleware.default_cors_config with origins = ["http://allowed.com"] } in
+  let handler = Kirin.Middleware.apply (Kirin.Middleware.cors ~config ()) base_handler in
+  let req_allowed = make_req ~headers:[("origin", "http://allowed.com")] "/" in
+  let resp_allowed = handler req_allowed in
+  check (option string) "allowed origin" (Some "http://allowed.com")
+    (Kirin.Response.header "Access-Control-Allow-Origin" resp_allowed);
+  let req_denied = make_req ~headers:[("origin", "http://denied.com")] "/" in
+  let resp_denied = handler req_denied in
+  check (option string) "denied origin" (Some "")
+    (Kirin.Response.header "Access-Control-Allow-Origin" resp_denied)
+
+(* -- run ----------------------------------------------------------- *)
+
+let () =
+  Eio_main.run @@ fun _env ->
+  Alcotest.run "Middleware" [
+    ("identity", [test_case "id passthrough" `Quick test_id]);
+    ("compose", [
+      test_case "compose order" `Quick test_compose_order;
+      test_case "infix compose" `Quick test_infix_compose;
+    ]);
+    ("pipeline", [
+      test_case "empty pipeline" `Quick test_pipeline_empty;
+      test_case "multiple middlewares" `Quick test_pipeline_multiple;
+    ]);
+    ("short-circuit", [test_case "early return" `Quick test_short_circuit]);
+    ("catch", [
+      test_case "catches exception" `Quick test_catch_handles_exception;
+      test_case "catch_default" `Quick test_catch_default;
+      test_case "passthrough on success" `Quick test_catch_passthrough_on_success;
+    ]);
+    ("with_headers", [test_case "adds headers" `Quick test_with_headers]);
+    ("timing", [test_case "adds timing header" `Quick test_timing_adds_header]);
+    ("cors", [
+      test_case "preflight response" `Quick test_cors_default_preflight;
+      test_case "normal request cors" `Quick test_cors_normal_request;
+      test_case "restricted origins" `Quick test_cors_restricted_origins;
+    ]);
+  ]

--- a/test/test_pool.ml
+++ b/test/test_pool.ml
@@ -1,0 +1,267 @@
+(** Connection Pool module tests.
+    Uses Eio_main.run because Pool relies on Eio.Mutex and Eio.Condition. *)
+
+open Alcotest
+
+let next_id = ref 0
+let mock_create () = incr next_id; !next_id
+let mock_destroy _conn = ()
+
+let make_pool ?min_size ?max_size ?validate () =
+  Kirin.Pool.create
+    ?min_size
+    ?max_size
+    ~idle_timeout:300.0
+    ~max_wait_time:1.0
+    ~create:mock_create
+    ~destroy:mock_destroy
+    ?validate
+    ()
+
+(* -- creation and defaults ----------------------------------------- *)
+
+let test_default_config () =
+  let c = Kirin.Pool.default_config in
+  check int "min_size" 1 c.Kirin.Pool.min_size;
+  check int "max_size" 10 c.Kirin.Pool.max_size
+
+let test_create_pool () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  let s = Kirin.Pool.stats pool in
+  check int "total 0" 0 s.Kirin.Pool.total_connections;
+  check int "active 0" 0 s.Kirin.Pool.active_connections;
+  check int "idle 0" 0 s.Kirin.Pool.idle_connections
+
+let creation_tests = [
+  test_case "default config" `Quick test_default_config;
+  test_case "create pool" `Quick test_create_pool;
+]
+
+(* -- acquire / release --------------------------------------------- *)
+
+let test_acquire_creates_connection () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  let pooled = Kirin.Pool.acquire pool in
+  check bool "conn > 0" true (pooled.Kirin.Pool.conn > 0);
+  check int "use_count" 1 pooled.Kirin.Pool.use_count;
+  let s = Kirin.Pool.stats pool in
+  check int "active 1" 1 s.Kirin.Pool.active_connections;
+  Kirin.Pool.release pool pooled
+
+let test_release_returns_to_pool () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  let pooled = Kirin.Pool.acquire pool in
+  Kirin.Pool.release pool pooled;
+  let s = Kirin.Pool.stats pool in
+  check int "active 0 after release" 0 s.Kirin.Pool.active_connections;
+  check int "idle 1" 1 s.Kirin.Pool.idle_connections
+
+let test_acquire_reuses_idle () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  let p1 = Kirin.Pool.acquire pool in
+  let conn_id = p1.Kirin.Pool.conn in
+  Kirin.Pool.release pool p1;
+  let p2 = Kirin.Pool.acquire pool in
+  check int "same connection reused" conn_id p2.Kirin.Pool.conn;
+  Kirin.Pool.release pool p2
+
+let test_multiple_acquire () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  let p1 = Kirin.Pool.acquire pool in
+  let p2 = Kirin.Pool.acquire pool in
+  check bool "different connections" true (p1.Kirin.Pool.conn <> p2.Kirin.Pool.conn);
+  let s = Kirin.Pool.stats pool in
+  check int "active 2" 2 s.Kirin.Pool.active_connections;
+  Kirin.Pool.release pool p1;
+  Kirin.Pool.release pool p2
+
+let acquire_tests = [
+  test_case "acquire creates" `Quick test_acquire_creates_connection;
+  test_case "release returns" `Quick test_release_returns_to_pool;
+  test_case "reuses idle" `Quick test_acquire_reuses_idle;
+  test_case "multiple acquire" `Quick test_multiple_acquire;
+]
+
+(* -- use ----------------------------------------------------------- *)
+
+let test_use_auto_release () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  let result = Kirin.Pool.use pool (fun conn -> conn * 10) in
+  check bool "result > 0" true (result > 0);
+  let s = Kirin.Pool.stats pool in
+  check int "active 0 after use" 0 s.Kirin.Pool.active_connections
+
+let test_use_releases_on_exception () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  (try
+     Kirin.Pool.use pool (fun _conn -> failwith "boom")
+   with Failure _ -> ());
+  let s = Kirin.Pool.stats pool in
+  check int "active 0 after exception" 0 s.Kirin.Pool.active_connections
+
+let test_use_pooled () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  let info = Kirin.Pool.use_pooled pool (fun p ->
+    (p.Kirin.Pool.conn, p.Kirin.Pool.use_count)
+  ) in
+  check bool "conn > 0" true (fst info > 0);
+  check int "use_count 1" 1 (snd info)
+
+let use_tests = [
+  test_case "use auto-release" `Quick test_use_auto_release;
+  test_case "use releases on exception" `Quick test_use_releases_on_exception;
+  test_case "use_pooled metadata" `Quick test_use_pooled;
+]
+
+(* -- pool size / stats --------------------------------------------- *)
+
+let test_size () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  let p1 = Kirin.Pool.acquire pool in
+  let (active, idle, max_sz) = Kirin.Pool.size pool in
+  check int "active" 1 active;
+  check int "idle" 0 idle;
+  check int "max" 5 max_sz;
+  Kirin.Pool.release pool p1
+
+let test_has_available () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:1 () in
+  check bool "available initially" true (Kirin.Pool.has_available pool);
+  let p1 = Kirin.Pool.acquire pool in
+  check bool "not available at max" false (Kirin.Pool.has_available pool);
+  Kirin.Pool.release pool p1;
+  check bool "available after release" true (Kirin.Pool.has_available pool)
+
+let test_idle_active_count () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  check int "idle 0" 0 (Kirin.Pool.idle_count pool);
+  check int "active 0" 0 (Kirin.Pool.active_count pool);
+  let p = Kirin.Pool.acquire pool in
+  check int "active 1" 1 (Kirin.Pool.active_count pool);
+  Kirin.Pool.release pool p;
+  check int "idle 1" 1 (Kirin.Pool.idle_count pool);
+  check int "active 0" 0 (Kirin.Pool.active_count pool)
+
+let size_tests = [
+  test_case "size tuple" `Quick test_size;
+  test_case "has_available" `Quick test_has_available;
+  test_case "idle/active count" `Quick test_idle_active_count;
+]
+
+(* -- init / shutdown ----------------------------------------------- *)
+
+let test_init_creates_minimum () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~min_size:3 ~max_size:5 () in
+  Kirin.Pool.init pool;
+  check int "idle 3" 3 (Kirin.Pool.idle_count pool)
+
+let test_shutdown () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~min_size:2 ~max_size:5 () in
+  Kirin.Pool.init pool;
+  Kirin.Pool.shutdown pool;
+  check int "idle 0 after shutdown" 0 (Kirin.Pool.idle_count pool)
+
+let lifecycle_tests = [
+  test_case "init creates minimum" `Quick test_init_creates_minimum;
+  test_case "shutdown clears all" `Quick test_shutdown;
+]
+
+(* -- maintenance --------------------------------------------------- *)
+
+let test_ensure_minimum () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~min_size:3 ~max_size:5 () in
+  let created = Kirin.Pool.ensure_minimum pool in
+  check int "created 3" 3 created;
+  check int "idle 3" 3 (Kirin.Pool.idle_count pool)
+
+let test_validate_all () =
+  Eio_main.run @@ fun _env ->
+  (* Use a mutable set of valid connections. Start all valid, then invalidate
+     one after release (so pool.release keeps it in the idle list). *)
+  let invalid_conns = Hashtbl.create 10 in
+  let pool = Kirin.Pool.create
+    ~min_size:1 ~max_size:5
+    ~idle_timeout:300.0 ~max_wait_time:1.0
+    ~create:mock_create
+    ~destroy:mock_destroy
+    ~validate:(fun conn -> not (Hashtbl.mem invalid_conns conn))
+    ()
+  in
+  let p1 = Kirin.Pool.acquire pool in
+  let p2 = Kirin.Pool.acquire pool in
+  let p3 = Kirin.Pool.acquire pool in
+  (* Release all -- all are valid during release so all go to idle *)
+  Kirin.Pool.release pool p1;
+  Kirin.Pool.release pool p2;
+  Kirin.Pool.release pool p3;
+  check int "3 idle before invalidation" 3 (Kirin.Pool.idle_count pool);
+  (* Now mark p2 as invalid *)
+  Hashtbl.replace invalid_conns p2.Kirin.Pool.conn true;
+  let removed = Kirin.Pool.validate_all pool in
+  check int "1 invalid removed" 1 removed;
+  check int "2 idle remain" 2 (Kirin.Pool.idle_count pool)
+
+let maintenance_tests = [
+  test_case "ensure_minimum" `Quick test_ensure_minimum;
+  test_case "validate_all" `Quick test_validate_all;
+]
+
+(* -- error_to_string ----------------------------------------------- *)
+
+let test_error_strings () =
+  check string "timeout" "Connection pool timeout"
+    (Kirin.Pool.error_to_string Kirin.Pool.Timeout);
+  check string "exhausted" "Connection pool exhausted"
+    (Kirin.Pool.error_to_string Kirin.Pool.Pool_exhausted);
+  check string "failed" "Connection failed: db down"
+    (Kirin.Pool.error_to_string (Kirin.Pool.Connection_failed "db down"));
+  check string "validation" "Connection validation failed"
+    (Kirin.Pool.error_to_string Kirin.Pool.Validation_failed)
+
+let error_tests = [
+  test_case "error_to_string" `Quick test_error_strings;
+]
+
+(* -- connection_info ----------------------------------------------- *)
+
+let test_connection_info () =
+  Eio_main.run @@ fun _env ->
+  let pool = make_pool ~max_size:5 () in
+  Kirin.Pool.use_pooled pool (fun p ->
+    let (age, idle, use_count) = Kirin.Pool.connection_info p in
+    check bool "age >= 0" true (age >= 0.0);
+    check bool "idle >= 0" true (idle >= 0.0);
+    check int "use_count" 1 use_count
+  )
+
+let info_tests = [
+  test_case "connection_info" `Quick test_connection_info;
+]
+
+(* -- run ----------------------------------------------------------- *)
+
+let () =
+  Alcotest.run "Pool" [
+    ("creation", creation_tests);
+    ("acquire/release", acquire_tests);
+    ("use", use_tests);
+    ("size", size_tests);
+    ("lifecycle", lifecycle_tests);
+    ("maintenance", maintenance_tests);
+    ("error", error_tests);
+    ("connection_info", info_tests);
+  ]

--- a/test/test_router.ml
+++ b/test/test_router.ml
@@ -1,0 +1,208 @@
+(** Router module tests *)
+
+open Alcotest
+
+let body_to_string = function
+  | Kirin.Response.String s -> s
+  | Kirin.Response.Stream _ -> "<stream>"
+  | Kirin.Response.Producer _ -> "<producer>"
+
+let make_req ?(meth = `GET) ?(headers = []) path =
+  let raw = Http.Request.make ~meth ~headers:(Http.Header.of_list headers) path in
+  let body_source = Eio.Flow.string_source "" |> Eio.Buf_read.of_flow ~max_size:1024 in
+  Kirin.Request.make ~raw ~body_source
+
+(* -- parse_pattern ------------------------------------------------- *)
+
+let test_parse_static () =
+  let segs = Kirin.Router.parse_pattern "/users/list" in
+  check int "segment count" 2 (List.length segs);
+  check bool "first is Static" true
+    (match List.nth segs 0 with Kirin.Router.Static "users" -> true | _ -> false);
+  check bool "second is Static" true
+    (match List.nth segs 1 with Kirin.Router.Static "list" -> true | _ -> false)
+
+let test_parse_param () =
+  let segs = Kirin.Router.parse_pattern "/users/:id" in
+  check int "segment count" 2 (List.length segs);
+  check bool "second is Param" true
+    (match List.nth segs 1 with Kirin.Router.Param "id" -> true | _ -> false)
+
+let test_parse_wildcard () =
+  let segs = Kirin.Router.parse_pattern "/files/*" in
+  check int "segment count" 2 (List.length segs);
+  check bool "second is Wildcard" true
+    (match List.nth segs 1 with Kirin.Router.Wildcard -> true | _ -> false)
+
+let test_parse_root () =
+  let segs = Kirin.Router.parse_pattern "/" in
+  check int "root has no segments" 0 (List.length segs)
+
+let parse_tests = [
+  test_case "static segments" `Quick test_parse_static;
+  test_case "param segments" `Quick test_parse_param;
+  test_case "wildcard segment" `Quick test_parse_wildcard;
+  test_case "root pattern" `Quick test_parse_root;
+]
+
+(* -- match_segments ------------------------------------------------ *)
+
+let test_match_static () =
+  let segs = [Kirin.Router.Static "users"; Kirin.Router.Static "list"] in
+  let result = Kirin.Router.match_segments segs ["users"; "list"] in
+  check bool "matches" true (Option.is_some result);
+  check int "no params" 0 (List.length (Option.get result))
+
+let test_match_param_extraction () =
+  let segs = [Kirin.Router.Static "users"; Kirin.Router.Param "id"] in
+  let result = Kirin.Router.match_segments segs ["users"; "42"] in
+  check bool "matches" true (Option.is_some result);
+  let params = Option.get result in
+  check (option string) "id param" (Some "42") (List.assoc_opt "id" params)
+
+let test_match_multi_params () =
+  let segs = [Kirin.Router.Static "users"; Kirin.Router.Param "uid";
+              Kirin.Router.Static "posts"; Kirin.Router.Param "pid"] in
+  let result = Kirin.Router.match_segments segs ["users"; "7"; "posts"; "99"] in
+  check bool "matches" true (Option.is_some result);
+  let params = Option.get result in
+  check (option string) "uid" (Some "7") (List.assoc_opt "uid" params);
+  check (option string) "pid" (Some "99") (List.assoc_opt "pid" params)
+
+let test_match_wildcard () =
+  let segs = [Kirin.Router.Static "files"; Kirin.Router.Wildcard] in
+  let result = Kirin.Router.match_segments segs ["files"; "a"; "b"; "c"] in
+  check bool "wildcard matches rest" true (Option.is_some result)
+
+let test_match_fail_extra_parts () =
+  let segs = [Kirin.Router.Static "users"] in
+  let result = Kirin.Router.match_segments segs ["users"; "extra"] in
+  check bool "no match with extra" true (Option.is_none result)
+
+let test_match_fail_missing_parts () =
+  let segs = [Kirin.Router.Static "users"; Kirin.Router.Static "list"] in
+  let result = Kirin.Router.match_segments segs ["users"] in
+  check bool "no match when missing" true (Option.is_none result)
+
+let test_match_fail_wrong_static () =
+  let segs = [Kirin.Router.Static "users"] in
+  let result = Kirin.Router.match_segments segs ["posts"] in
+  check bool "no match wrong static" true (Option.is_none result)
+
+let match_tests = [
+  test_case "static match" `Quick test_match_static;
+  test_case "param extraction" `Quick test_match_param_extraction;
+  test_case "multi param extraction" `Quick test_match_multi_params;
+  test_case "wildcard matches rest" `Quick test_match_wildcard;
+  test_case "fail on extra path parts" `Quick test_match_fail_extra_parts;
+  test_case "fail on missing parts" `Quick test_match_fail_missing_parts;
+  test_case "fail on wrong static" `Quick test_match_fail_wrong_static;
+]
+
+(* -- dispatch / find_route ----------------------------------------- *)
+
+let handler_ok _req = Kirin.Response.text "ok"
+
+let test_dispatch_get () =
+  let routes = [Kirin.Router.get "/hello" handler_ok] in
+  let req = make_req "/hello" in
+  let resp = Kirin.Router.dispatch routes req in
+  check int "200 status" 200 (Kirin.Response.status_code resp);
+  check string "body" "ok" (body_to_string (Kirin.Response.body resp))
+
+let test_dispatch_post () =
+  let routes = [Kirin.Router.post "/items" (fun _req -> Kirin.Response.text "created")] in
+  let req = make_req ~meth:`POST "/items" in
+  let resp = Kirin.Router.dispatch routes req in
+  check string "body" "created" (body_to_string (Kirin.Response.body resp))
+
+let test_dispatch_put () =
+  let routes = [Kirin.Router.put "/items/:id" (fun req ->
+    let id = match Kirin.Request.param "id" req with Some v -> v | None -> "?" in
+    Kirin.Response.text ("updated:" ^ id)
+  )] in
+  let req = make_req ~meth:`PUT "/items/5" in
+  let resp = Kirin.Router.dispatch routes req in
+  check string "body" "updated:5" (body_to_string (Kirin.Response.body resp))
+
+let test_dispatch_delete () =
+  let routes = [Kirin.Router.delete "/items/:id" (fun _req -> Kirin.Response.text "deleted")] in
+  let req = make_req ~meth:`DELETE "/items/3" in
+  let resp = Kirin.Router.dispatch routes req in
+  check string "body" "deleted" (body_to_string (Kirin.Response.body resp))
+
+let test_dispatch_404 () =
+  let routes = [Kirin.Router.get "/exists" handler_ok] in
+  let req = make_req "/missing" in
+  let resp = Kirin.Router.dispatch routes req in
+  check int "404" 404 (Kirin.Response.status_code resp)
+
+let test_dispatch_method_mismatch () =
+  let routes = [Kirin.Router.get "/only-get" handler_ok] in
+  let req = make_req ~meth:`POST "/only-get" in
+  let resp = Kirin.Router.dispatch routes req in
+  check int "404 on wrong method" 404 (Kirin.Response.status_code resp)
+
+let test_dispatch_first_match_wins () =
+  let routes = [
+    Kirin.Router.get "/test" (fun _req -> Kirin.Response.text "first");
+    Kirin.Router.get "/test" (fun _req -> Kirin.Response.text "second");
+  ] in
+  let req = make_req "/test" in
+  let resp = Kirin.Router.dispatch routes req in
+  check string "first match" "first" (body_to_string (Kirin.Response.body resp))
+
+let test_router_function () =
+  let routes = [Kirin.Router.get "/" handler_ok] in
+  let handler = Kirin.Router.router routes in
+  let req = make_req "/" in
+  let resp = handler req in
+  check int "status" 200 (Kirin.Response.status_code resp)
+
+let dispatch_tests = [
+  test_case "GET dispatch" `Quick test_dispatch_get;
+  test_case "POST dispatch" `Quick test_dispatch_post;
+  test_case "PUT with param" `Quick test_dispatch_put;
+  test_case "DELETE dispatch" `Quick test_dispatch_delete;
+  test_case "404 for unmatched" `Quick test_dispatch_404;
+  test_case "404 on method mismatch" `Quick test_dispatch_method_mismatch;
+  test_case "first match wins" `Quick test_dispatch_first_match_wins;
+  test_case "router function" `Quick test_router_function;
+]
+
+(* -- scope --------------------------------------------------------- *)
+
+let test_scope_prefix () =
+  let inner = [Kirin.Router.get "/items" (fun _req -> Kirin.Response.text "scoped")] in
+  let scoped = Kirin.Router.scope "/api" [] inner in
+  let req = make_req "/api/items" in
+  let resp = Kirin.Router.dispatch scoped req in
+  check string "scoped body" "scoped" (body_to_string (Kirin.Response.body resp))
+
+let test_scope_with_middleware () =
+  let add_header : Kirin.Middleware.t = fun handler req ->
+    let resp = handler req in
+    Kirin.Response.with_header "x-scoped" "yes" resp
+  in
+  let inner = [Kirin.Router.get "/data" (fun _req -> Kirin.Response.text "data")] in
+  let scoped = Kirin.Router.scope "/v1" [add_header] inner in
+  let req = make_req "/v1/data" in
+  let resp = Kirin.Router.dispatch scoped req in
+  check (option string) "middleware header" (Some "yes")
+    (Kirin.Response.header "x-scoped" resp)
+
+let scope_tests = [
+  test_case "scope adds prefix" `Quick test_scope_prefix;
+  test_case "scope applies middleware" `Quick test_scope_with_middleware;
+]
+
+(* -- run ----------------------------------------------------------- *)
+
+let () =
+  Eio_main.run @@ fun _env ->
+  Alcotest.run "Router" [
+    ("parse_pattern", parse_tests);
+    ("match_segments", match_tests);
+    ("dispatch", dispatch_tests);
+    ("scope", scope_tests);
+  ]

--- a/test/test_sse.ml
+++ b/test/test_sse.ml
@@ -1,0 +1,195 @@
+(** Server-Sent Events module tests *)
+
+open Alcotest
+
+(** Check if [sub] is a substring of [s]. *)
+let contains s sub =
+  let slen = String.length s in
+  let sublen = String.length sub in
+  if sublen > slen then false
+  else
+    let rec check i =
+      if i > slen - sublen then false
+      else if String.sub s i sublen = sub then true
+      else check (i + 1)
+    in
+    check 0
+
+(* -- event constructors -------------------------------------------- *)
+
+let test_data_only () =
+  let e = Kirin.Sse.data "hello" in
+  check (option string) "no event type" None e.Kirin.Sse.event;
+  check string "data" "hello" e.Kirin.Sse.data;
+  check (option string) "no id" None e.Kirin.Sse.id;
+  check (option int) "no retry" None e.Kirin.Sse.retry
+
+let test_event_with_type () =
+  let e = Kirin.Sse.event "message" "payload" in
+  check (option string) "event type" (Some "message") e.Kirin.Sse.event;
+  check string "data" "payload" e.Kirin.Sse.data
+
+let test_event_typed () =
+  let e = Kirin.Sse.event_typed ~event_type:"custom" "body" in
+  check (option string) "event type" (Some "custom") e.Kirin.Sse.event;
+  check string "data" "body" e.Kirin.Sse.data
+
+let test_with_id () =
+  let e = Kirin.Sse.data "test" |> Kirin.Sse.with_id "42" in
+  check (option string) "id" (Some "42") e.Kirin.Sse.id
+
+let test_with_retry () =
+  let e = Kirin.Sse.data "test" |> Kirin.Sse.with_retry 5000 in
+  check (option int) "retry" (Some 5000) e.Kirin.Sse.retry
+
+let test_chained_builders () =
+  let e = Kirin.Sse.event "tick" "data"
+    |> Kirin.Sse.with_id "99"
+    |> Kirin.Sse.with_retry 3000
+  in
+  check (option string) "event" (Some "tick") e.Kirin.Sse.event;
+  check string "data" "data" e.Kirin.Sse.data;
+  check (option string) "id" (Some "99") e.Kirin.Sse.id;
+  check (option int) "retry" (Some 3000) e.Kirin.Sse.retry
+
+let constructor_tests = [
+  test_case "data only" `Quick test_data_only;
+  test_case "event with type" `Quick test_event_with_type;
+  test_case "event_typed" `Quick test_event_typed;
+  test_case "with_id" `Quick test_with_id;
+  test_case "with_retry" `Quick test_with_retry;
+  test_case "chained builders" `Quick test_chained_builders;
+]
+
+(* -- encode -------------------------------------------------------- *)
+
+let test_encode_data_only () =
+  let e = Kirin.Sse.data "hello" in
+  let encoded = Kirin.Sse.encode e in
+  check string "data-only" "data: hello\n\n" encoded
+
+let test_encode_with_event_type () =
+  let e = Kirin.Sse.event "update" "new data" in
+  let encoded = Kirin.Sse.encode e in
+  check bool "has event field" true (contains encoded "event: update\n");
+  check bool "has data field" true (contains encoded "data: new data\n");
+  check bool "ends with double newline" true
+    (let len = String.length encoded in
+     len >= 2 && String.sub encoded (len - 2) 2 = "\n\n")
+
+let test_encode_with_id () =
+  let e = Kirin.Sse.data "msg" |> Kirin.Sse.with_id "7" in
+  let encoded = Kirin.Sse.encode e in
+  check bool "has id field" true (contains encoded "id: 7\n")
+
+let test_encode_with_retry () =
+  let e = Kirin.Sse.data "msg" |> Kirin.Sse.with_retry 1000 in
+  let encoded = Kirin.Sse.encode e in
+  check bool "has retry field" true (contains encoded "retry: 1000\n")
+
+let test_encode_multiline_data () =
+  let e = Kirin.Sse.data "line1\nline2\nline3" in
+  let encoded = Kirin.Sse.encode e in
+  check bool "first line" true (contains encoded "data: line1\n");
+  check bool "second line" true (contains encoded "data: line2\n");
+  check bool "third line" true (contains encoded "data: line3\n")
+
+let test_encode_full_event () =
+  let e = Kirin.Sse.event "msg" "payload"
+    |> Kirin.Sse.with_id "42"
+    |> Kirin.Sse.with_retry 5000
+  in
+  let encoded = Kirin.Sse.encode e in
+  check bool "has event" true (contains encoded "event: msg\n");
+  check bool "has data" true (contains encoded "data: payload\n");
+  check bool "has id" true (contains encoded "id: 42\n");
+  check bool "has retry" true (contains encoded "retry: 5000\n")
+
+let encode_tests = [
+  test_case "data only" `Quick test_encode_data_only;
+  test_case "with event type" `Quick test_encode_with_event_type;
+  test_case "with id" `Quick test_encode_with_id;
+  test_case "with retry" `Quick test_encode_with_retry;
+  test_case "multiline data" `Quick test_encode_multiline_data;
+  test_case "full event" `Quick test_encode_full_event;
+]
+
+(* -- ping ---------------------------------------------------------- *)
+
+let test_ping () =
+  check string "ping format" ": ping\n\n" Kirin.Sse.ping
+
+let ping_tests = [
+  test_case "ping comment" `Quick test_ping;
+]
+
+(* -- broadcaster --------------------------------------------------- *)
+
+let test_broadcaster_subscribe_unsubscribe () =
+  Eio_main.run @@ fun _env ->
+  let b = Kirin.Sse.Broadcaster.create () in
+  let (id, _stream) = Kirin.Sse.Broadcaster.subscribe b in
+  check bool "id >= 0" true (id >= 0);
+  Kirin.Sse.Broadcaster.unsubscribe b id
+
+let test_broadcaster_broadcast () =
+  Eio_main.run @@ fun _env ->
+  let b = Kirin.Sse.Broadcaster.create () in
+  let (_id1, stream1) = Kirin.Sse.Broadcaster.subscribe b in
+  let (_id2, stream2) = Kirin.Sse.Broadcaster.subscribe b in
+  let evt = Kirin.Sse.data "broadcast-test" in
+  Kirin.Sse.Broadcaster.broadcast b evt;
+  let received1 = Eio.Stream.take_nonblocking stream1 in
+  let received2 = Eio.Stream.take_nonblocking stream2 in
+  check bool "client1 received" true (Option.is_some received1);
+  check bool "client2 received" true (Option.is_some received2);
+  check string "client1 data" "broadcast-test" (Option.get received1).Kirin.Sse.data;
+  check string "client2 data" "broadcast-test" (Option.get received2).Kirin.Sse.data
+
+let test_broadcaster_unsubscribed_not_receive () =
+  Eio_main.run @@ fun _env ->
+  let b = Kirin.Sse.Broadcaster.create () in
+  let (id1, stream1) = Kirin.Sse.Broadcaster.subscribe b in
+  Kirin.Sse.Broadcaster.unsubscribe b id1;
+  Kirin.Sse.Broadcaster.broadcast b (Kirin.Sse.data "after-unsub");
+  let received = Eio.Stream.take_nonblocking stream1 in
+  check bool "unsubscribed gets nothing" true (Option.is_none received)
+
+let broadcaster_tests = [
+  test_case "subscribe/unsubscribe" `Quick test_broadcaster_subscribe_unsubscribe;
+  test_case "broadcast to all" `Quick test_broadcaster_broadcast;
+  test_case "unsubscribed skipped" `Quick test_broadcaster_unsubscribed_not_receive;
+]
+
+(* -- response_legacy ----------------------------------------------- *)
+
+let test_response_legacy_empty () =
+  let resp = Kirin.Sse.response_legacy [] in
+  check int "200 status" 200 (Kirin.Response.status_code resp);
+  check (option string) "content-type" (Some "text/event-stream")
+    (Kirin.Response.header "Content-Type" resp)
+
+let test_response_legacy_events () =
+  let events = [Kirin.Sse.data "a"; Kirin.Sse.data "b"] in
+  let resp = Kirin.Sse.response_legacy events in
+  match Kirin.Response.body resp with
+  | Kirin.Response.String body ->
+    check bool "contains data: a" true (contains body "data: a\n");
+    check bool "contains data: b" true (contains body "data: b\n")
+  | _ -> fail "expected String body"
+
+let legacy_tests = [
+  test_case "empty legacy response" `Quick test_response_legacy_empty;
+  test_case "legacy with events" `Quick test_response_legacy_events;
+]
+
+(* -- run ----------------------------------------------------------- *)
+
+let () =
+  Alcotest.run "SSE" [
+    ("constructors", constructor_tests);
+    ("encode", encode_tests);
+    ("ping", ping_tests);
+    ("broadcaster", broadcaster_tests);
+    ("response_legacy", legacy_tests);
+  ]

--- a/test/test_websocket.ml
+++ b/test/test_websocket.ml
@@ -1,0 +1,280 @@
+(** WebSocket module tests *)
+
+open Alcotest
+
+(* -- opcode conversion --------------------------------------------- *)
+
+let test_opcode_of_int () =
+  check bool "text" true (Kirin.Websocket.opcode_of_int 0x1 = Some Kirin.Websocket.Text);
+  check bool "binary" true (Kirin.Websocket.opcode_of_int 0x2 = Some Kirin.Websocket.Binary);
+  check bool "close" true (Kirin.Websocket.opcode_of_int 0x8 = Some Kirin.Websocket.Close);
+  check bool "ping" true (Kirin.Websocket.opcode_of_int 0x9 = Some Kirin.Websocket.Ping);
+  check bool "pong" true (Kirin.Websocket.opcode_of_int 0xA = Some Kirin.Websocket.Pong);
+  check bool "continuation" true (Kirin.Websocket.opcode_of_int 0x0 = Some Kirin.Websocket.Continuation);
+  check bool "invalid" true (Kirin.Websocket.opcode_of_int 0x3 = None)
+
+let test_int_of_opcode () =
+  check int "text" 0x1 (Kirin.Websocket.int_of_opcode Kirin.Websocket.Text);
+  check int "binary" 0x2 (Kirin.Websocket.int_of_opcode Kirin.Websocket.Binary);
+  check int "close" 0x8 (Kirin.Websocket.int_of_opcode Kirin.Websocket.Close);
+  check int "ping" 0x9 (Kirin.Websocket.int_of_opcode Kirin.Websocket.Ping);
+  check int "pong" 0xA (Kirin.Websocket.int_of_opcode Kirin.Websocket.Pong);
+  check int "continuation" 0x0 (Kirin.Websocket.int_of_opcode Kirin.Websocket.Continuation)
+
+let test_opcode_roundtrip () =
+  let opcodes = [Kirin.Websocket.Continuation; Text; Binary; Close; Ping; Pong] in
+  List.iter (fun op ->
+    let n = Kirin.Websocket.int_of_opcode op in
+    check bool "roundtrip"
+      true (Kirin.Websocket.opcode_of_int n = Some op)
+  ) opcodes
+
+let opcode_tests = [
+  test_case "opcode_of_int" `Quick test_opcode_of_int;
+  test_case "int_of_opcode" `Quick test_int_of_opcode;
+  test_case "roundtrip" `Quick test_opcode_roundtrip;
+]
+
+(* -- close codes --------------------------------------------------- *)
+
+let test_close_code_values () =
+  check int "Normal" 1000 (Kirin.Websocket.int_of_close_code Kirin.Websocket.Normal);
+  check int "GoingAway" 1001 (Kirin.Websocket.int_of_close_code Kirin.Websocket.GoingAway);
+  check int "ProtocolError" 1002 (Kirin.Websocket.int_of_close_code Kirin.Websocket.ProtocolError);
+  check int "UnsupportedData" 1003 (Kirin.Websocket.int_of_close_code Kirin.Websocket.UnsupportedData);
+  check int "InvalidPayload" 1007 (Kirin.Websocket.int_of_close_code Kirin.Websocket.InvalidPayload);
+  check int "PolicyViolation" 1008 (Kirin.Websocket.int_of_close_code Kirin.Websocket.PolicyViolation);
+  check int "MessageTooBig" 1009 (Kirin.Websocket.int_of_close_code Kirin.Websocket.MessageTooBig);
+  check int "InternalError" 1011 (Kirin.Websocket.int_of_close_code Kirin.Websocket.InternalError)
+
+let test_close_code_roundtrip () =
+  let codes = [
+    Kirin.Websocket.Normal; GoingAway; ProtocolError; UnsupportedData;
+    InvalidPayload; PolicyViolation; MessageTooBig; InternalError;
+  ] in
+  List.iter (fun c ->
+    let n = Kirin.Websocket.int_of_close_code c in
+    check bool "close roundtrip" true (Kirin.Websocket.close_code_of_int n = Some c)
+  ) codes
+
+let test_close_code_unknown () =
+  check bool "unknown code" true (Kirin.Websocket.close_code_of_int 9999 = None)
+
+let close_code_tests = [
+  test_case "close code values" `Quick test_close_code_values;
+  test_case "close code roundtrip" `Quick test_close_code_roundtrip;
+  test_case "unknown close code" `Quick test_close_code_unknown;
+]
+
+(* -- apply_mask ---------------------------------------------------- *)
+
+let test_mask_identity () =
+  let mask = "\x12\x34\x56\x78" in
+  let payload = "Hello, WebSocket" in
+  let masked = Kirin.Websocket.apply_mask mask payload in
+  let unmasked = Kirin.Websocket.apply_mask mask masked in
+  check string "roundtrip" payload unmasked
+
+let test_mask_empty () =
+  let mask = "\x00\x00\x00\x00" in
+  let result = Kirin.Websocket.apply_mask mask "" in
+  check string "empty" "" result
+
+let test_mask_zero_key () =
+  let mask = "\x00\x00\x00\x00" in
+  let payload = "abc" in
+  let result = Kirin.Websocket.apply_mask mask payload in
+  check string "zero mask = identity" payload result
+
+let mask_tests = [
+  test_case "mask/unmask roundtrip" `Quick test_mask_identity;
+  test_case "empty payload" `Quick test_mask_empty;
+  test_case "zero mask key" `Quick test_mask_zero_key;
+]
+
+(* -- frame constructors -------------------------------------------- *)
+
+let test_text_frame () =
+  let f = Kirin.Websocket.text_frame "hello" in
+  check bool "fin" true f.Kirin.Websocket.fin;
+  check bool "opcode is Text" true (f.Kirin.Websocket.opcode = Kirin.Websocket.Text);
+  check string "payload" "hello" f.Kirin.Websocket.payload
+
+let test_text_frame_continuation () =
+  let f = Kirin.Websocket.text_frame ~fin:false "part1" in
+  check bool "not fin" false f.Kirin.Websocket.fin
+
+let test_binary_frame () =
+  let f = Kirin.Websocket.binary_frame "\x00\x01\x02" in
+  check bool "opcode is Binary" true (f.Kirin.Websocket.opcode = Kirin.Websocket.Binary);
+  check string "payload" "\x00\x01\x02" f.Kirin.Websocket.payload
+
+let test_ping_frame () =
+  let f = Kirin.Websocket.ping_frame () in
+  check bool "opcode is Ping" true (f.Kirin.Websocket.opcode = Kirin.Websocket.Ping);
+  check string "empty payload" "" f.Kirin.Websocket.payload
+
+let test_ping_frame_with_payload () =
+  let f = Kirin.Websocket.ping_frame ~payload:"heartbeat" () in
+  check string "payload" "heartbeat" f.Kirin.Websocket.payload
+
+let test_pong_frame () =
+  let f = Kirin.Websocket.pong_frame ~payload:"heartbeat" in
+  check bool "opcode is Pong" true (f.Kirin.Websocket.opcode = Kirin.Websocket.Pong);
+  check string "payload echoes" "heartbeat" f.Kirin.Websocket.payload
+
+let test_close_frame_default () =
+  let f = Kirin.Websocket.close_frame () in
+  check bool "opcode is Close" true (f.Kirin.Websocket.opcode = Kirin.Websocket.Close);
+  check bool "fin" true f.Kirin.Websocket.fin;
+  check bool "payload >= 2 bytes" true (String.length f.Kirin.Websocket.payload >= 2)
+
+let test_close_frame_with_reason () =
+  let f = Kirin.Websocket.close_frame ~code:Kirin.Websocket.GoingAway ~reason:"bye" () in
+  check bool "payload has reason" true (String.length f.Kirin.Websocket.payload > 2)
+
+let frame_tests = [
+  test_case "text frame" `Quick test_text_frame;
+  test_case "text continuation" `Quick test_text_frame_continuation;
+  test_case "binary frame" `Quick test_binary_frame;
+  test_case "ping frame" `Quick test_ping_frame;
+  test_case "ping with payload" `Quick test_ping_frame_with_payload;
+  test_case "pong frame" `Quick test_pong_frame;
+  test_case "close frame default" `Quick test_close_frame_default;
+  test_case "close frame with reason" `Quick test_close_frame_with_reason;
+]
+
+(* -- encode/decode roundtrip --------------------------------------- *)
+
+let test_encode_small_text () =
+  let frame = Kirin.Websocket.text_frame "Hi" in
+  let encoded = Kirin.Websocket.encode_frame frame in
+  (* First byte: 0x80 | 0x01 = 0x81, second byte: 2 (length) *)
+  check int "encoded length" 4 (String.length encoded);
+  check int "first byte" 0x81 (Char.code encoded.[0]);
+  check int "length byte" 2 (Char.code encoded.[1])
+
+let test_encode_medium_payload () =
+  let payload = String.make 200 'x' in
+  let frame = Kirin.Websocket.text_frame payload in
+  let encoded = Kirin.Websocket.encode_frame frame in
+  (* 2 header + 2 extended length + 200 payload = 204 *)
+  check int "encoded length" 204 (String.length encoded);
+  check int "length indicator" 126 (Char.code encoded.[1])
+
+let test_encode_decode_roundtrip () =
+  let payload = "test" in
+  let mask_key = "\xAA\xBB\xCC\xDD" in
+  let masked_payload = Kirin.Websocket.apply_mask mask_key payload in
+  let buf = Buffer.create 32 in
+  Buffer.add_char buf (Char.chr 0x81);
+  Buffer.add_char buf (Char.chr (0x80 lor String.length payload));
+  Buffer.add_string buf mask_key;
+  Buffer.add_string buf masked_payload;
+  let data = Buffer.contents buf in
+  match Kirin.Websocket.decode_frame data with
+  | Ok (frame, consumed) ->
+    check bool "fin" true frame.Kirin.Websocket.fin;
+    check bool "opcode Text" true (frame.Kirin.Websocket.opcode = Kirin.Websocket.Text);
+    check string "decoded payload" payload frame.Kirin.Websocket.payload;
+    check int "consumed bytes" (String.length data) consumed
+  | Error msg ->
+    fail ("decode failed: " ^ msg)
+
+let test_decode_too_short () =
+  match Kirin.Websocket.decode_frame "\x81" with
+  | Error _ -> ()
+  | Ok _ -> fail "should fail on short data"
+
+let test_decode_unmasked () =
+  let data = "\x81\x02Hi" in
+  match Kirin.Websocket.decode_frame data with
+  | Ok (frame, _) ->
+    check string "payload" "Hi" frame.Kirin.Websocket.payload
+  | Error msg ->
+    fail ("unmasked decode: " ^ msg)
+
+let encode_tests = [
+  test_case "encode small text" `Quick test_encode_small_text;
+  test_case "encode medium payload" `Quick test_encode_medium_payload;
+  test_case "encode/decode roundtrip (masked)" `Quick test_encode_decode_roundtrip;
+  test_case "decode too short" `Quick test_decode_too_short;
+  test_case "decode unmasked" `Quick test_decode_unmasked;
+]
+
+(* -- parse_close_payload ------------------------------------------- *)
+
+let test_parse_close_normal () =
+  let f = Kirin.Websocket.close_frame ~code:Kirin.Websocket.Normal ~reason:"goodbye" () in
+  let (code, reason) = Kirin.Websocket.parse_close_payload f.Kirin.Websocket.payload in
+  check bool "code is Normal" true (code = Some Kirin.Websocket.Normal);
+  check string "reason" "goodbye" reason
+
+let test_parse_close_empty () =
+  let (code, reason) = Kirin.Websocket.parse_close_payload "" in
+  check bool "no code" true (code = None);
+  check string "no reason" "" reason
+
+let test_parse_close_code_only () =
+  let f = Kirin.Websocket.close_frame ~code:Kirin.Websocket.GoingAway () in
+  let (code, reason) = Kirin.Websocket.parse_close_payload f.Kirin.Websocket.payload in
+  check bool "GoingAway" true (code = Some Kirin.Websocket.GoingAway);
+  check string "empty reason" "" reason
+
+let close_payload_tests = [
+  test_case "parse normal close" `Quick test_parse_close_normal;
+  test_case "parse empty close" `Quick test_parse_close_empty;
+  test_case "parse code-only close" `Quick test_parse_close_code_only;
+]
+
+(* -- compute_accept_key -------------------------------------------- *)
+
+let test_accept_key () =
+  let result = Kirin.Websocket.compute_accept_key "dGhlIHNhbXBsZSBub25jZQ==" in
+  check string "RFC 6455 test vector" "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" result
+
+let handshake_tests = [
+  test_case "accept key (RFC 6455)" `Quick test_accept_key;
+]
+
+(* -- echo_handler -------------------------------------------------- *)
+
+let test_echo_text () =
+  let frame = Kirin.Websocket.text_frame "echo me" in
+  let result = Kirin.Websocket.echo_handler.Kirin.Websocket.on_message frame in
+  check bool "returns frame" true (Option.is_some result);
+  let resp = Option.get result in
+  check string "echoed payload" "echo me" resp.Kirin.Websocket.payload
+
+let test_echo_ping_to_pong () =
+  let frame = Kirin.Websocket.ping_frame ~payload:"ping-data" () in
+  let result = Kirin.Websocket.echo_handler.Kirin.Websocket.on_message frame in
+  check bool "returns pong" true (Option.is_some result);
+  let resp = Option.get result in
+  check bool "is pong" true (resp.Kirin.Websocket.opcode = Kirin.Websocket.Pong);
+  check string "pong payload" "ping-data" resp.Kirin.Websocket.payload
+
+let test_echo_close_ignored () =
+  let frame = Kirin.Websocket.close_frame () in
+  let result = Kirin.Websocket.echo_handler.Kirin.Websocket.on_message frame in
+  check bool "close returns None" true (Option.is_none result)
+
+let echo_tests = [
+  test_case "echo text" `Quick test_echo_text;
+  test_case "ping to pong" `Quick test_echo_ping_to_pong;
+  test_case "close ignored" `Quick test_echo_close_ignored;
+]
+
+(* -- run ----------------------------------------------------------- *)
+
+let () =
+  Alcotest.run "Websocket" [
+    ("opcode", opcode_tests);
+    ("close_code", close_code_tests);
+    ("mask", mask_tests);
+    ("frame_constructors", frame_tests);
+    ("encode/decode", encode_tests);
+    ("close_payload", close_payload_tests);
+    ("handshake", handshake_tests);
+    ("echo_handler", echo_tests);
+  ]


### PR DESCRIPTION
## Summary
- Add 143 new tests across 7 dedicated test files for under-tested core modules
- Cache (26 tests): LRU eviction, TTL expiry, statistics, StringCache/IntCache specializations, memoize, cleanup
- Pool (18 tests): acquire/release cycle, use with auto-release, init/shutdown lifecycle, validate_all, connection_info
- WebSocket (29 tests): opcode/close_code roundtrips, XOR masking, frame encode/decode, RFC 6455 accept key vector, echo handler
- SSE (18 tests): event constructors and chaining, wire format encoding, multiline data, Broadcaster pub/sub, response_legacy
- Router (21 tests): parse_pattern segments, match_segments with params/wildcards, dispatch across HTTP methods, scope with middleware
- Middleware (14 tests): identity/compose/pipeline, short-circuit, catch/catch_default, with_headers, timing, CORS preflight + restricted origins
- Cookie (17 tests): parse_cookies, build_set_cookie with all attributes, signed cookies (HMAC-SHA256 sign/verify), delete

## Test plan
- [x] All 143 new tests pass locally (`dune test --root .`)
- [x] Full existing test suite (1,053 tests) unaffected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)