### PR TITLE
fix: add Eio.Cancel.Cancelled guard to 14 catch sites

### DIFF
--- a/lib/astro/protocol.ml
+++ b/lib/astro/protocol.ml
@@ -109,7 +109,9 @@ let decode_response s =
         | d -> Some d
       in
       Error { id; code; message; data }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error { id = 0; code = parse_error; message = Printexc.to_string e; data = None }
 
 (** {1 Response Construction} *)

--- a/lib/cluster.ml
+++ b/lib/cluster.ml
@@ -49,7 +49,9 @@ let spawn_worker id entry_point =
   match fork () with 
   | 0 -> (* Child *)
     Printf.printf "[Worker %d] Started (PID: %d)\n%!" id (getpid ());
-    (try entry_point () with e -> 
+    (try entry_point () with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | e ->
       Printf.eprintf "[Worker %d] Crashed: %s\n%!" id (Printexc.to_string e));
     exit 0
   | pid -> (* Parent *)

--- a/lib/grpc.ml
+++ b/lib/grpc.ml
@@ -178,7 +178,9 @@ let timing_interceptor () =
 let catch_interceptor ~on_error () =
   make_interceptor "kirin-catch" (fun ctx next ->
     try next ctx
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
       let status = on_error exn in
       { Interceptor.value = ""; trailers = [("grpc-status", string_of_int status)] })
 

--- a/lib/jobs.ml
+++ b/lib/jobs.ml
@@ -132,7 +132,9 @@ let take_job t =
 let process_job t job =
   let result =
     try Ok (job.task ())
-    with exn -> Error exn
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error exn
   in
   Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
     match result with

--- a/lib/metric_prometheus.ml
+++ b/lib/metric_prometheus.ml
@@ -188,7 +188,9 @@ let middleware ?(normalize_path = default_normalize_path) http_metrics handler r
   Metric_gauge.inc http_metrics.requests_in_flight;
 
   let start = Time_compat.now () in
-  let resp = try handler req with exn ->
+  let resp = try handler req with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
     Metric_gauge.dec http_metrics.requests_in_flight;
     raise exn
   in

--- a/lib/middleware.ml
+++ b/lib/middleware.ml
@@ -44,7 +44,9 @@ let logger : t = fun handler req ->
 (** Error catcher middleware *)
 let catch (error_handler : exn -> Request.t -> Response.t) : t = fun handler req ->
   try handler req
-  with exn -> error_handler exn req
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> error_handler exn req
 
 (** Default error handler *)
 let default_error_handler exn _req =

--- a/lib/qwik/protocol.ml
+++ b/lib/qwik/protocol.ml
@@ -111,7 +111,9 @@ let decode_response str =
       let code = error |> member "code" |> to_int in
       let message = error |> member "message" |> to_string in
       Failure { id; code; message }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Failure { id = 0; code = -32700; message = Printexc.to_string e }
 
 (** {1 Health Check} *)
@@ -143,7 +145,9 @@ let decode_batch str =
     | `List items ->
       List.map (fun item -> decode_response (Yojson.Safe.to_string item)) items
     | _ -> [Failure { id = 0; code = -32600; message = "Invalid batch response" }]
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     [Failure { id = 0; code = -32700; message = Printexc.to_string e }]
 
 (** {1 Serialization} *)

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -101,7 +101,9 @@ let make_cohttp_handler ~clock ~config sw (handler : Router.handler) =
         (* Create stream, fork producer, stream chunks to client *)
         let stream = Eio.Stream.create 16 in
         Eio.Fiber.fork ~sw (fun () ->
-          try p stream with exn ->
+          try p stream with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
             Logger.error "Stream producer error: %s" (Printexc.to_string exn);
             (* Signal end of stream on error *)
             Eio.Stream.add stream None
@@ -168,7 +170,9 @@ let start ?(port = 8000) ?(request_timeout = 30.0) ?(stream_read_timeout = 5.0) 
       Cohttp_eio.Server.run socket server ~on_error:(fun exn ->
         Logger.error "Worker error on domain %d: %s" (Domain.self () :> int) (Printexc.to_string exn)
       )
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Logger.error "Fatal worker error: %s" (Printexc.to_string e)
   in
 

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -142,7 +142,9 @@ let run_hooks t =
   let hooks = with_lock t (fun () -> t.hooks) in
   List.iter (fun hook ->
     try hook ()
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
       Printf.eprintf "Shutdown hook error: %s\n%!" (Printexc.to_string exn)
   ) hooks
 
@@ -211,7 +213,9 @@ let run t server_fn =
   setup_signals t;
   try
     server_fn ()
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
     Printf.eprintf "Server error: %s\n%!" (Printexc.to_string exn);
     initiate t
 

--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -203,7 +203,9 @@ let read_with_progress ~(request : Request.t) ~chunk_size ~(progress : progress_
       progress.on_progress ~bytes_sent:!bytes_sent ~total_bytes:total_opt
     );
     progress.on_complete ()
-  with e -> 
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     progress.on_error e;
     raise e
 

--- a/lib/trace.ml
+++ b/lib/trace.ml
@@ -191,7 +191,9 @@ let middleware ?(exporter : (module EXPORTER) option) () : Middleware.t =
     (* Call handler *)
     let resp =
       try handler req
-      with exn ->
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
         set_error span (Printexc.to_string exn);
         finish span;
         (match exporter with Some (module E : EXPORTER) -> E.export span | None -> ());


### PR DESCRIPTION
## Summary

- Added `Eio.Cancel.Cancelled _ as e -> raise e` guard to 14 unguarded `with e ->` / `with exn ->` catches across 11 files
- Without this guard, Eio fiber cancellation exceptions are silently swallowed, preventing clean shutdown propagation through the fiber tree
- Intentionally skipped `solid/worker.ml` (2 sites) -- those run in forked Unix processes, not Eio fibers

## Files changed

| File | Sites | Context |
|------|-------|---------|
| `server.ml` | 2 | stream producer fork, worker run loop |
| `shutdown.ml` | 2 | hook runner, server_fn wrapper |
| `middleware.ml` | 1 | catch error handler |
| `jobs.ml` | 1 | job task execution |
| `cluster.ml` | 1 | worker entry_point |
| `trace.ml` | 1 | span error recording |
| `metric_prometheus.ml` | 1 | in-flight gauge tracking |
| `stream.ml` | 1 | progress error callback |
| `grpc.ml` | 1 | catch interceptor |
| `astro/protocol.ml` | 1 | JSON parse catch |
| `qwik/protocol.ml` | 2 | JSON parse + batch parse |

## Additional audit findings (no action needed)

- **Stdlib.Mutex** in `logger.ml`: intentional and documented -- cross-domain synchronization via `Domain.spawn` requires OS mutex, not Eio.Mutex
- **Fun.protect**: 18 usages across `testing.ml`, `pool.ml`, `shutdown.ml`, `stream.ml`, `auth/secure_random.ml`, `logger.ml`, `mcp/session.ml` -- all are resource cleanup (fd close, stream signal) which is the correct use case
- **Codebase size**: 218 `.ml` files, 218 `.mli` files (full interface coverage)

## Test plan

- [x] `dune build` passes
- [x] `dune test` passes (all test suites green)
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)