### PR TITLE
fix(sec): CORS empty origin + body size 413 response

### DIFF
--- a/lib/middleware.ml
+++ b/lib/middleware.ml
@@ -81,32 +81,45 @@ let cors ?(config = default_cors_config) () : t = fun handler req ->
     (* Determine the Allow-Origin value.
        - Never reflect an empty or missing Origin.
        - credentials:true + wildcard origins is invalid per the CORS spec;
-         we only reflect the concrete origin when it matches the allow-list. *)
-    let origin_header =
+         we only reflect the concrete origin when it matches the allow-list.
+       - When origin is not allowed, return None so no CORS headers are added. *)
+    let origin_value =
       match origin with
       | None | Some "" ->
-        (* No Origin header: only send "*" when credentials are off *)
-        if config.credentials then "" else
-        (match config.origins with ["*"] -> "*" | _ -> "")
+        (* No Origin header: only send "*" when credentials are off and
+           origins are wildcard. Otherwise, deny. *)
+        if config.credentials then None
+        else (match config.origins with ["*"] -> Some "*" | _ -> None)
       | Some o ->
         (match config.origins with
-         | ["*"] -> if config.credentials then o else o
-         | origins -> if List.mem o origins then o else "")
+         | ["*"] -> Some o  (* Always reflect concrete origin, never "*" with a real Origin *)
+         | origins -> if List.mem o origins then Some o else None)
     in
-    let resp = resp
-      |> Response.with_header "Access-Control-Allow-Origin" origin_header
-      |> Response.with_header "Access-Control-Allow-Methods" (String.concat ", " config.methods)
-      |> Response.with_header "Access-Control-Allow-Headers" (String.concat ", " config.headers)
-    in
-    (* credentials:true must never be combined with Allow-Origin: "*" *)
-    let resp =
-      if config.credentials && origin_header <> "" && origin_header <> "*"
-      then Response.with_header "Access-Control-Allow-Credentials" "true" resp
-      else resp
-    in
-    match config.max_age with
-    | Some age -> Response.with_header "Access-Control-Max-Age" (string_of_int age) resp
-    | None -> resp
+    match origin_value with
+    | None ->
+      (* Origin not allowed: do not add any CORS headers.
+         Add common non-CORS headers (methods, max-age) only on preflight. *)
+      resp
+    | Some ov ->
+      let resp = resp
+        |> Response.with_header "Access-Control-Allow-Origin" ov
+        |> Response.with_header "Access-Control-Allow-Methods" (String.concat ", " config.methods)
+        |> Response.with_header "Access-Control-Allow-Headers" (String.concat ", " config.headers)
+      in
+      (* When reflecting a specific origin (not "*"), add Vary: Origin
+         to prevent cache poisoning. *)
+      let resp =
+        if ov <> "*" then Response.with_header "Vary" "Origin" resp else resp
+      in
+      (* credentials:true must never be combined with Allow-Origin: "*" *)
+      let resp =
+        if config.credentials && ov <> "*"
+        then Response.with_header "Access-Control-Allow-Credentials" "true" resp
+        else resp
+      in
+      (match config.max_age with
+       | Some age -> Response.with_header "Access-Control-Max-Age" (string_of_int age) resp
+       | None -> resp)
   in
 
   if is_preflight then

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -61,7 +61,9 @@ let make_stream_source (stream : string option Eio.Stream.t) : Eio.Flow.source_t
 let make_cohttp_handler ~clock ~config _sw (handler : Router.handler) =
   fun _socket request body ->
     (* Create Kirin request with raw body source (Zero-Copy) *)
-    (* Cohttp_eio passes body as Flow source, convert to Buf_read *)
+    (* Cohttp_eio passes body as Flow source, convert to Buf_read.
+       max_size enforces the body limit; Buf_read.Buffer_limit_exceeded
+       is raised lazily when the handler reads beyond the limit. *)
     let body_buf = Eio.Buf_read.of_flow body ~initial_size:4096 ~max_size:config.max_body_size in
     let req = Request.make ~raw:request ~body_source:body_buf in
 
@@ -83,7 +85,18 @@ let make_cohttp_handler ~clock ~config _sw (handler : Router.handler) =
             (`String "{\"error\":\"Request timeout\"}")
     in
 
-    let resp = handle_with_timeout () in
+    let resp =
+      try handle_with_timeout ()
+      with Eio.Buf_read.Buffer_limit_exceeded ->
+        Logger.warn "Request body too large (limit %d bytes): %s %s"
+          config.max_body_size
+          (Http.Method.to_string (Cohttp.Request.meth request))
+          (Cohttp.Request.resource request);
+        Response.make
+          ~status:`Request_entity_too_large
+          ~headers:(Cohttp.Header.of_list [("content-type", "application/json")])
+          (`String (Printf.sprintf "{\"error\":\"Request body too large\",\"max_bytes\":%d}" config.max_body_size))
+    in
 
     (* Convert to cohttp-eio response *)
     let status = Response.status resp in

--- a/test/test_middleware.ml
+++ b/test/test_middleware.ml
@@ -152,8 +152,11 @@ let test_cors_restricted_origins () =
     (Kirin.Response.header "Access-Control-Allow-Origin" resp_allowed);
   let req_denied = make_req ~headers:[("origin", "http://denied.com")] "/" in
   let resp_denied = handler req_denied in
-  check (option string) "denied origin" (Some "")
-    (Kirin.Response.header "Access-Control-Allow-Origin" resp_denied)
+  (* Denied origin: no CORS headers at all *)
+  check (option string) "denied origin omitted" None
+    (Kirin.Response.header "Access-Control-Allow-Origin" resp_denied);
+  check (option string) "denied: no methods header" None
+    (Kirin.Response.header "Access-Control-Allow-Methods" resp_denied)
 
 (* -- cors: issue #45 regressions ------------------------------------- *)
 
@@ -184,9 +187,29 @@ let test_cors_credentials_wildcard_no_star () =
   let resp = handler req in
   let allow_origin = Kirin.Response.header "Access-Control-Allow-Origin" resp in
   let allow_creds = Kirin.Response.header "Access-Control-Allow-Credentials" resp in
+  let vary = Kirin.Response.header "Vary" resp in
   (* Must reflect the concrete origin, not "*" *)
   check (option string) "reflects origin" (Some "http://example.com") allow_origin;
-  check (option string) "credentials set" (Some "true") allow_creds
+  check (option string) "credentials set" (Some "true") allow_creds;
+  (* Vary: Origin required when reflecting a specific origin *)
+  check (option string) "vary origin" (Some "Origin") vary
+
+(* Vary: Origin must be set when reflecting a specific origin *)
+let test_cors_vary_origin_on_reflect () =
+  let handler = Kirin.Middleware.apply (Kirin.Middleware.cors ()) base_handler in
+  let req = make_req ~headers:[("origin", "http://example.com")] "/" in
+  let resp = handler req in
+  (* Wildcard config reflects the concrete origin, so Vary is required *)
+  check (option string) "vary header set" (Some "Origin")
+    (Kirin.Response.header "Vary" resp)
+
+(* Vary: Origin must NOT be set when Allow-Origin is "*" *)
+let test_cors_no_vary_on_wildcard_without_origin () =
+  let handler = Kirin.Middleware.apply (Kirin.Middleware.cors ()) base_handler in
+  let req = make_req "/" in  (* no Origin header -> Allow-Origin: * *)
+  let resp = handler req in
+  check (option string) "no vary on wildcard" None
+    (Kirin.Response.header "Vary" resp)
 
 let test_cors_credentials_no_origin () =
   let config = { Kirin.Middleware.default_cors_config with
@@ -197,9 +220,9 @@ let test_cors_credentials_no_origin () =
   let resp = handler req in
   let allow_origin = Kirin.Response.header "Access-Control-Allow-Origin" resp in
   let allow_creds = Kirin.Response.header "Access-Control-Allow-Credentials" resp in
-  (* No origin + credentials: empty allow-origin, no credentials header *)
-  check (option string) "no origin reflected" (Some "") allow_origin;
-  check (option string) "no credentials header" None allow_creds
+  (* No origin + credentials: no CORS headers at all *)
+  check (option string) "no origin: no allow-origin header" None allow_origin;
+  check (option string) "no origin: no credentials header" None allow_creds
 
 (* -- run ----------------------------------------------------------- *)
 
@@ -230,6 +253,8 @@ let () =
       test_case "no origin header" `Quick test_cors_no_origin_header;
       test_case "empty origin header" `Quick test_cors_empty_origin_header;
       test_case "credentials+wildcard no star" `Quick test_cors_credentials_wildcard_no_star;
+      test_case "vary origin on reflect" `Quick test_cors_vary_origin_on_reflect;
+      test_case "no vary on wildcard" `Quick test_cors_no_vary_on_wildcard_without_origin;
       test_case "credentials without origin" `Quick test_cors_credentials_no_origin;
     ]);
   ]


### PR DESCRIPTION
## Summary
- **#45 CORS empty origin**: When the request origin is disallowed (missing, empty, or not in the allow-list), no CORS headers are emitted at all instead of sending an empty `Access-Control-Allow-Origin` header. Adds `Vary: Origin` when reflecting a specific origin to prevent cache poisoning.
- **#40 Unbounded body OOM**: Catches `Eio.Buf_read.Buffer_limit_exceeded` in the request handler and returns a proper 413 (Request Entity Too Large) JSON response instead of crashing with an unhandled exception.

## Changes
| File | What |
|------|------|
| `lib/middleware.ml` | CORS `add_cors_headers` rewritten: `origin_header` string replaced with `origin_value` option; `None` skips all CORS headers; `Vary: Origin` added on non-wildcard reflection |
| `lib/server.ml` | `make_cohttp_handler` wraps `handle_with_timeout()` in try/with for `Buffer_limit_exceeded` -> 413 |
| `test/test_middleware.ml` | 2 new tests (Vary header), updated denied-origin and credentials-no-origin assertions to expect `None` instead of `Some ""` |

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root .` -- all test suites green (20 middleware tests, 0 failures across all suites)
- [ ] Manual: `curl -H "Origin: " localhost:8000/` should return no `Access-Control-Allow-Origin` header
- [ ] Manual: POST body > 10MB should return 413

Closes #45
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)