### PR TITLE
chore: bump version 2.0.0 -> 2.0.3

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -2,7 +2,7 @@
 
 (name kirin)
 
-(version 2.0.0)
+(version 2.0.3)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary
- dune-project version was 2.0.0 while latest git tag is v2.0.2
- 3 security fixes committed since v2.0.2 warrant 2.0.3
- Aligns dune-project with actual release state

## Test plan
- [x] `dune build` passes (version field only)

Generated with [Claude Code](https://claude.com/claude-code)