### PR TITLE
fix(auth): replace global ref data race with per-request Hmap context

### DIFF
--- a/lib/auth/auth_middleware.ml
+++ b/lib/auth/auth_middleware.ml
@@ -3,6 +3,9 @@
     Middleware for protecting routes with various authentication strategies.
     Supports JWT Bearer tokens, Session-based auth, and API keys.
 
+    Auth info is stored in the per-request Hmap context, so concurrent
+    fibers serving different requests never share state.
+
     {b Example:}
     {[
       (* JWT protected route *)
@@ -30,17 +33,19 @@ type auth_info = {
 (** Header for storing auth info *)
 let auth_header = "X-Auth-Info"
 
-(** Internal ref to pass auth info through handler chain *)
-let current_auth : auth_info option ref = ref None
+(** Hmap key for storing auth_info in Request.ctx.
+    Each request carries its own Hmap, eliminating data races
+    that the previous global ref caused under concurrent fibers. *)
+let auth_key : auth_info Hmap.key = Hmap.Key.create ()
 
-(** Store auth info for current request *)
-let set_auth_info _req info =
-  current_auth := Some info;
-  _req  (* Return unchanged request *)
+(** Store auth info in the request context. Returns a new request. *)
+let set_auth_info req info =
+  let ctx = Hmap.add auth_key info (Kirin.Request.ctx req) in
+  Kirin.Request.with_ctx ctx req
 
-(** Get auth info from current request *)
-let get_auth_info _req =
-  !current_auth
+(** Get auth info from request context *)
+let get_auth_info req =
+  Hmap.find auth_key (Kirin.Request.ctx req)
 
 (** Get user ID from authenticated request *)
 let get_user_id req =
@@ -71,7 +76,6 @@ let jwt ~secret ?(on_error = fun _req msg ->
     Kirin.Response.json ~status:`Unauthorized
       (`Assoc [("error", `String msg)])) handler =
   fun req ->
-    current_auth := None;  (* Reset auth for each request *)
     match extract_bearer_token req with
     | None -> on_error req "Missing or invalid Authorization header"
     | Some token ->
@@ -88,7 +92,6 @@ let jwt_with_claims ~secret ~extract_user_id ?on_error handler =
   let on_error = Option.value on_error ~default:(fun _req msg ->
     Kirin.Response.json ~status:`Unauthorized (`Assoc [("error", `String msg)])) in
   fun req ->
-    current_auth := None;  (* Reset auth for each request *)
     match extract_bearer_token req with
     | None -> on_error req "Missing Authorization header"
     | Some token ->

--- a/lib/auth/auth_middleware.mli
+++ b/lib/auth/auth_middleware.mli
@@ -1,14 +1,23 @@
+(** Authentication middleware.
+
+    Auth info is stored per-request in [Kirin.Request.ctx] via [Hmap],
+    so concurrent fibers never share mutable state. *)
+
 type auth_info = {
   user_id : string;
   claims : Yojson.Safe.t option;
   token_type : string;
 }
+
 val auth_header : string
-val current_auth : auth_info option ref
-val set_auth_info : 'a -> auth_info -> 'a
-val get_auth_info : 'a -> auth_info option
-val get_user_id : 'a -> string option
-val get_claims : 'a -> Yojson.Safe.t option
+
+(** Hmap key used to store [auth_info] in the request context. *)
+val auth_key : auth_info Hmap.key
+
+val set_auth_info : Kirin.Request.t -> auth_info -> Kirin.Request.t
+val get_auth_info : Kirin.Request.t -> auth_info option
+val get_user_id : Kirin.Request.t -> string option
+val get_claims : Kirin.Request.t -> Yojson.Safe.t option
 val extract_bearer_token : Kirin.Request.t -> string option
 val jwt :
   secret:string ->
@@ -36,13 +45,18 @@ val api_key :
   (Kirin.Request.t -> Kirin.Response.t) ->
   Kirin.Request.t -> Kirin.Response.t
 val optional_jwt :
-  secret:string -> (Kirin.Request.t -> 'a) -> Kirin.Request.t -> 'a
+  secret:string ->
+  (Kirin.Request.t -> Kirin.Response.t) ->
+  Kirin.Request.t -> Kirin.Response.t
 val require_role :
   role_claim:string ->
   required_roles:string list ->
-  ?on_error:('a -> Kirin.Response.t) ->
-  ('a -> Kirin.Response.t) -> 'a -> Kirin.Response.t
+  ?on_error:(Kirin.Request.t -> Kirin.Response.t) ->
+  (Kirin.Request.t -> Kirin.Response.t) ->
+  Kirin.Request.t -> Kirin.Response.t
 val any_of :
-  (('a -> Kirin.Response.t) -> 'b -> Kirin.Response.t) list ->
-  ?on_error:('b -> Kirin.Response.t) ->
-  ('a -> Kirin.Response.t) -> 'b -> Kirin.Response.t
+  ((Kirin.Request.t -> Kirin.Response.t) ->
+   Kirin.Request.t -> Kirin.Response.t) list ->
+  ?on_error:(Kirin.Request.t -> Kirin.Response.t) ->
+  (Kirin.Request.t -> Kirin.Response.t) ->
+  Kirin.Request.t -> Kirin.Response.t

--- a/test/dune
+++ b/test/dune
@@ -4,7 +4,7 @@
 
 (test
  (name test_auth)
- (libraries kirin kirin.auth alcotest str unix eio_main))
+ (libraries kirin kirin.auth alcotest str unix eio eio_main hmap))
 
 (test
  (name test_mcp)

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -215,6 +215,130 @@ let oauth2_tests = [
   test_case "pkce" `Quick test_oauth2_pkce;
 ]
 
+(** {1 Auth Middleware Tests (Hmap context, no global ref)} *)
+
+let make_req ?(meth = `GET) ?(headers = []) path =
+  let raw = Http.Request.make ~meth ~headers:(Http.Header.of_list headers) path in
+  let body_source = Eio.Buf_read.of_flow ~max_size:1024 (Eio.Flow.string_source "") in
+  Kirin.Request.make ~raw ~body_source
+
+(** set_auth_info stores into Hmap, get_auth_info reads back *)
+let test_middleware_set_get_auth_info () =
+  let req = make_req "/" in
+  check (option string) "no auth initially" None
+    (Kirin_auth.Middleware.get_user_id req);
+  let info : Kirin_auth.Middleware.auth_info =
+    { user_id = "u-42"; claims = None; token_type = "test" }
+  in
+  let req2 = Kirin_auth.Middleware.set_auth_info req info in
+  check (option string) "user_id present after set" (Some "u-42")
+    (Kirin_auth.Middleware.get_user_id req2);
+  (* Original request is unchanged (immutable Hmap) *)
+  check (option string) "original req unaffected" None
+    (Kirin_auth.Middleware.get_user_id req)
+
+(** JWT middleware stores auth info in per-request context *)
+let test_middleware_jwt_success () =
+  let payload = `Assoc [("role", `String "admin")] in
+  let token = Kirin_auth.Jwt.encode ~secret:jwt_secret ~payload
+    ~sub:"user-99" ~exp:(Unix.gettimeofday () +. 3600.) () in
+  let req = make_req ~headers:[("Authorization", "Bearer " ^ token)] "/api" in
+  let captured_uid = ref None in
+  let handler req =
+    captured_uid := Kirin_auth.Middleware.get_user_id req;
+    Kirin.Response.text "ok"
+  in
+  let protected = Kirin_auth.Middleware.jwt ~secret:jwt_secret handler in
+  let _resp = protected req in
+  check (option string) "handler sees user_id" (Some "user-99") !captured_uid
+
+(** JWT middleware returns 401 on missing token *)
+let test_middleware_jwt_missing_token () =
+  let req = make_req "/api" in
+  let handler _req = Kirin.Response.text "ok" in
+  let protected = Kirin_auth.Middleware.jwt ~secret:jwt_secret handler in
+  let resp = protected req in
+  check int "401 on missing token" 401
+    (Http.Status.to_int (Kirin.Response.status resp))
+
+(** Two fibers with different auth info do not interfere.
+    This is the scenario that the old global ref got wrong. *)
+let test_middleware_concurrent_isolation () =
+  Eio_main.run @@ fun _env ->
+    let token_a = Kirin_auth.Jwt.encode ~secret:jwt_secret
+      ~payload:(`Assoc []) ~sub:"alice" ~exp:(Unix.gettimeofday () +. 3600.) () in
+    let token_b = Kirin_auth.Jwt.encode ~secret:jwt_secret
+      ~payload:(`Assoc []) ~sub:"bob" ~exp:(Unix.gettimeofday () +. 3600.) () in
+    let req_a = make_req ~headers:[("Authorization", "Bearer " ^ token_a)] "/" in
+    let req_b = make_req ~headers:[("Authorization", "Bearer " ^ token_b)] "/" in
+    let uid_a = ref None in
+    let uid_b = ref None in
+    let handler_a req =
+      (* Yield to let fiber B run and set its own auth *)
+      Eio.Fiber.yield ();
+      uid_a := Kirin_auth.Middleware.get_user_id req;
+      Kirin.Response.text "a"
+    in
+    let handler_b req =
+      uid_b := Kirin_auth.Middleware.get_user_id req;
+      Kirin.Response.text "b"
+    in
+    Eio.Fiber.both
+      (fun () ->
+        ignore (Kirin_auth.Middleware.jwt ~secret:jwt_secret handler_a req_a))
+      (fun () ->
+        ignore (Kirin_auth.Middleware.jwt ~secret:jwt_secret handler_b req_b));
+    (* Each fiber must see its own user, never the other *)
+    check (option string) "fiber A sees alice" (Some "alice") !uid_a;
+    check (option string) "fiber B sees bob" (Some "bob") !uid_b
+
+(** get_claims returns claims from Hmap context *)
+let test_middleware_get_claims () =
+  let payload = `Assoc [("role", `String "admin")] in
+  let token = Kirin_auth.Jwt.encode ~secret:jwt_secret ~payload
+    ~sub:"user-1" ~exp:(Unix.gettimeofday () +. 3600.) () in
+  let req = make_req ~headers:[("Authorization", "Bearer " ^ token)] "/" in
+  let captured_claims = ref None in
+  let handler req =
+    captured_claims := Kirin_auth.Middleware.get_claims req;
+    Kirin.Response.text "ok"
+  in
+  ignore (Kirin_auth.Middleware.jwt ~secret:jwt_secret handler req);
+  match !captured_claims with
+  | None -> fail "claims should be present"
+  | Some claims ->
+    (match Yojson.Safe.Util.member "role" claims with
+     | `String "admin" -> ()
+     | _ -> fail "role claim missing")
+
+(** API key middleware stores auth info in request context *)
+let test_middleware_api_key () =
+  let validate = function
+    | "valid-key-123" -> Some "api-user-7"
+    | _ -> None
+  in
+  let req = make_req ~headers:[("X-API-Key", "valid-key-123")] "/" in
+  let captured = ref None in
+  let handler req =
+    captured := Kirin_auth.Middleware.get_auth_info req;
+    Kirin.Response.text "ok"
+  in
+  ignore (Kirin_auth.Middleware.api_key ~validate handler req);
+  match !captured with
+  | None -> fail "auth_info should be set for valid API key"
+  | Some info ->
+    check string "user_id from api key" "api-user-7" info.user_id;
+    check string "token_type" "api_key" info.token_type
+
+let middleware_tests = [
+  test_case "set/get auth info via Hmap" `Quick test_middleware_set_get_auth_info;
+  test_case "jwt success" `Quick test_middleware_jwt_success;
+  test_case "jwt missing token" `Quick test_middleware_jwt_missing_token;
+  test_case "concurrent fiber isolation" `Quick test_middleware_concurrent_isolation;
+  test_case "get_claims" `Quick test_middleware_get_claims;
+  test_case "api_key" `Quick test_middleware_api_key;
+]
+
 (** {1 Main} *)
 
 let () =
@@ -224,4 +348,5 @@ let () =
     ("Session", session_tests);
     ("Csrf", csrf_tests);
     ("Oauth2", oauth2_tests);
+    ("Middleware", middleware_tests);
   ]


### PR DESCRIPTION
## Summary
- Replace the module-level `current_auth` ref in `auth_middleware.ml` with an `Hmap.key` stored in `Request.ctx`, eliminating the data race under concurrent Eio fibers
- Remove `current_auth` from the public `.mli` API and tighten type signatures from polymorphic to `Kirin.Request.t`
- Add 6 new middleware tests including a concurrent fiber isolation test that spawns two fibers with different JWT tokens and verifies they never see each other's auth state

Closes #39
Ref #49 (ratelimit Eio.Mutex was already applied in dc8189d)

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root .` passes (26 auth tests, 204 core tests)
- [x] New `test_middleware_concurrent_isolation`: two Eio fibers with `Fiber.both` + `Fiber.yield` prove auth state is per-request
- [x] New `test_middleware_set_get_auth_info`: verifies original request is unaffected after `set_auth_info` (immutable Hmap)
- [x] New `test_middleware_jwt_success`, `test_middleware_jwt_missing_token`, `test_middleware_get_claims`, `test_middleware_api_key`

Generated with [Claude Code](https://claude.com/claude-code)