### PR TITLE
fix: replace eprintf with structured Logger (8 calls, 6 files)

### DIFF
--- a/lib/middleware.ml
+++ b/lib/middleware.ml
@@ -25,19 +25,11 @@ let logger : t = fun handler req ->
   let start_time = Unix.gettimeofday () in
   let meth = Http.Method.to_string (Request.meth req) in
   let path = Request.path req in
-  Printf.eprintf "[%s] %s %s\n%!"
-    (let tm = Unix.localtime start_time in
-     Printf.sprintf "%02d:%02d:%02d" tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec)
-    meth path;
-
+  Logger.info "%s %s" meth path;
   let response = handler req in
-
   let elapsed = Unix.gettimeofday () -. start_time in
   let status = Http.Status.to_int (Response.status response) in
-  Printf.eprintf "[%s] %s %s -> %d (%.3fms)\n%!"
-    (let tm = Unix.localtime (Unix.gettimeofday ()) in
-     Printf.sprintf "%02d:%02d:%02d" tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec)
-    meth path status (elapsed *. 1000.0);
+  Logger.info "%s %s -> %d (%.3fms)" meth path status (elapsed *. 1000.0);
 
   response
 
@@ -50,7 +42,7 @@ let catch (error_handler : exn -> Request.t -> Response.t) : t = fun handler req
 
 (** Default error handler *)
 let default_error_handler exn _req =
-  Printf.eprintf "Error: %s\n%!" (Printexc.to_string exn);
+  Logger.error "Unhandled: %s" (Printexc.to_string exn);
   Response.server_error ()
 
 (** Catch with default error handler *)

--- a/lib/qwik/ssr.ml
+++ b/lib/qwik/ssr.ml
@@ -227,7 +227,7 @@ let prerender engine ~routes ~output_dir =
       let file_path = Filename.concat output_dir (path ^ ".html") in
       Kirin.Fs_compat.save file_path html
     | Error msg ->
-      Printf.eprintf "Failed to prerender %s: %s\n" url msg
+      Kirin.Logger.error "Failed to prerender %s: %s" url msg
   ) routes
 
 (** {1 Shutdown} *)

--- a/lib/react/node_worker.ml
+++ b/lib/react/node_worker.ml
@@ -93,7 +93,7 @@ let start_process config =
       close_noerr stdout_w;
       raise e
   with Unix.Unix_error (err, _, _) ->
-    Printf.eprintf "Failed to start Node.js: %s\n%!" (Unix.error_message err);
+    Kirin.Logger.error "Failed to start Node.js: %s" (Unix.error_message err);
     None
 
 (** Create new worker *)

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -142,7 +142,7 @@ let run ?(config = default_config) ~sw ~env handler =
 
   let server = Cohttp_eio.Server.make ~callback:(make_cohttp_handler ~clock ~config sw handler) () in
   Cohttp_eio.Server.run socket server ~on_error:(fun exn ->
-    Printf.eprintf "Server error: %s\n%!" (Printexc.to_string exn)
+    Logger.error "Server error: %s" (Printexc.to_string exn)
   )
 
 (** Main entry point - sets up Eio and runs multicore server

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -145,7 +145,7 @@ let run_hooks t =
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn ->
-      Printf.eprintf "Shutdown hook error: %s\n%!" (Printexc.to_string exn)
+      Logger.warn "Shutdown hook error: %s" (Printexc.to_string exn)
   ) hooks
 
 (** {1 Shutdown Process} *)
@@ -216,7 +216,7 @@ let run t server_fn =
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-    Printf.eprintf "Server error: %s\n%!" (Printexc.to_string exn);
+    Logger.error "Server error: %s" (Printexc.to_string exn);
     initiate t
 
 (** Middleware that tracks connections and handles shutdown *)

--- a/lib/solid/ssr.ml
+++ b/lib/solid/ssr.ml
@@ -64,7 +64,7 @@ let start engine =
     match Worker.start worker with
     | Ok () -> ()
     | Error msg ->
-      Printf.eprintf "Failed to start SSR worker: %s\n" msg
+      Kirin.Logger.error "Failed to start SSR worker: %s" msg
   ) engine.pool
 
 (** Stop all workers *)


### PR DESCRIPTION
lib/ 내 eprintf를 Logger로 전환. cluster.ml(fork), trace.ml(exporter), stream.ml(progress)는 유지.