### PR TITLE
fix(cookie): use constant-time HMAC comparison

### DIFF
--- a/lib/cookie.ml
+++ b/lib/cookie.ml
@@ -138,7 +138,7 @@ let verify signed_value =
       let value = String.sub signed_value 0 idx in
       let signature = String.sub signed_value (idx + 1) (String.length signed_value - idx - 1) in
       let expected_sig = sign value in
-      if signature = expected_sig then
+      if Eqaf.equal signature expected_sig then
         Some value
       else
         None

--- a/lib/dune
+++ b/lib/dune
@@ -13,6 +13,7 @@
   cstruct
   base64
   digestif
+  eqaf
   decompress.de
   decompress.gz
   decompress.zl


### PR DESCRIPTION
## Summary
- Replace structural equality (`=`) with `Eqaf.equal` in `Cookie.verify` for HMAC signature comparison
- Prevents timing side-channel attacks that can leak information about expected signatures byte-by-byte
- Consistent with `auth/jwt.ml` which already uses `Eqaf.equal` for the same purpose

## Changes
- `lib/cookie.ml`: `signature = expected_sig` -> `Eqaf.equal signature expected_sig`
- `lib/dune`: add `eqaf` dependency (already transitively installed via `digestif`)

## Test plan
- [ ] `dune build` passes (verified locally)
- [ ] Existing cookie tests still pass
- [ ] Verify `eqaf` is available in CI (transitive dep of `digestif`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)