### PR TITLE
fix(i18n): split West Slavic plural rules from East Slavic per CLDR

### DIFF
--- a/lib/i18n.ml
+++ b/lib/i18n.ml
@@ -82,12 +82,20 @@ let plural_category locale count =
     if count = 0 || count = 1 then One else Other
   | "ko" | "ja" | "zh" | "vi" | "th" ->
     Other  (* No plural distinction *)
-  | "ru" | "uk" | "pl" | "cs" | "sk" ->
+  | "ru" | "uk" ->
+    (* East Slavic: 1,21,31.. -> One; 2-4,22-24.. -> Few; rest -> Many *)
     let mod10 = count mod 10 in
     let mod100 = count mod 100 in
     if mod10 = 1 && mod100 <> 11 then One
-    else if mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20) then Few
+    else if mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14) then Few
     else Many
+  | "pl" | "cs" | "sk" ->
+    (* West Slavic: exactly 1 -> One; 2-4,22-24.. -> Few; rest -> Other *)
+    let mod10 = count mod 10 in
+    let mod100 = count mod 100 in
+    if count = 1 then One
+    else if mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14) then Few
+    else Other
   | "ar" ->
     if count = 0 then Zero
     else if count = 1 then One

--- a/test/test_i18n.ml
+++ b/test/test_i18n.ml
@@ -143,6 +143,43 @@ let plural_tests = [
     Alcotest.(check string) "many" "5 элементов" msg5
   );
 
+  "polish plural (west slavic)", `Quick, (fun () ->
+    (* Polish: exactly 1 -> One, 2-4/22-24/32-34 -> Few, rest -> Other.
+       Unlike Russian where 21 -> One, Polish 21 -> Other. *)
+    let i18n = I18n.create ()
+      |> I18n.add_plural "pl" ~key:"items"
+           ~one:"{{count}} plik"
+           ~few:"{{count}} pliki"
+           ~other:"{{count}} plików" in
+    let msg1 = I18n.translate i18n ~locale:"pl" ~count:1 "items" in
+    let msg2 = I18n.translate i18n ~locale:"pl" ~count:2 "items" in
+    let msg5 = I18n.translate i18n ~locale:"pl" ~count:5 "items" in
+    let msg21 = I18n.translate i18n ~locale:"pl" ~count:21 "items" in
+    let msg22 = I18n.translate i18n ~locale:"pl" ~count:22 "items" in
+    Alcotest.(check string) "one" "1 plik" msg1;
+    Alcotest.(check string) "few" "2 pliki" msg2;
+    Alcotest.(check string) "other" "5 plików" msg5;
+    (* 21 in Polish is Other, not One (unlike Russian) *)
+    Alcotest.(check string) "21 other" "21 plików" msg21;
+    Alcotest.(check string) "22 few" "22 pliki" msg22
+  );
+
+  "russian 21 is one", `Quick, (fun () ->
+    (* Russian: 21 -> One (unlike Polish). Verify the split works both ways. *)
+    let i18n = I18n.create ()
+      |> I18n.add_plural "ru" ~key:"items"
+           ~one:"{{count}} элемент"
+           ~few:"{{count}} элемента"
+           ~many:"{{count}} элементов"
+           ~other:"{{count}} элементов" in
+    let msg21 = I18n.translate i18n ~locale:"ru" ~count:21 "items" in
+    let msg22 = I18n.translate i18n ~locale:"ru" ~count:22 "items" in
+    let msg11 = I18n.translate i18n ~locale:"ru" ~count:11 "items" in
+    Alcotest.(check string) "21 one" "21 элемент" msg21;
+    Alcotest.(check string) "22 few" "22 элемента" msg22;
+    Alcotest.(check string) "11 many" "11 элементов" msg11
+  );
+
   "arabic plural zero", `Quick, (fun () ->
     let i18n = I18n.create ()
       |> I18n.add_plural "ar" ~key:"items"


### PR DESCRIPTION
## Summary
- Split Polish/Czech/Slovak (West Slavic) plural rules from Russian/Ukrainian (East Slavic) in `plural_category`
- West Slavic uses `n == 1` for One form (only exact 1), East Slavic uses `n%10 == 1 && n%100 != 11` (1, 21, 31...)
- Previous code applied Russian rules to all five languages, causing Polish `count=21` to incorrectly select the One form ("21 plik" instead of "21 plików")
- Aligned Few condition with CLDR wording: `mod100 < 12 || mod100 > 14` (functionally equivalent but clearer)
- Added 2 test cases: Polish plural boundaries + Russian count=21 verification

## Test plan
- [x] `dune build --root .` passes
- [x] `dune exec --root . test/test_i18n.exe` passes (38 tests, 0 failures)
- [x] New Polish test verifies count=21 maps to Other (not One)
- [x] New Russian test verifies count=21 maps to One (confirming the split)

Generated with [Claude Code](https://claude.com/claude-code)