### PR TITLE
test: initialize Time_compat clock inside with_eio helper

### DIFF
--- a/test/test_helpers.ml
+++ b/test/test_helpers.ml
@@ -28,8 +28,17 @@ let string_contains haystack needle =
     in
     check 0
 
-(** Run a test function inside the Eio runtime (simple, no switch/clock) *)
-let with_eio f () = Eio_main.run @@ fun _env -> f ()
+(** Run a test function inside the Eio runtime.
+
+    Sets the global [Time_compat] clock from [Eio.Stdenv.clock env] so any
+    [Kirin.Time_compat.sleep] / [.now] call inside the test resolves. Without
+    this, tests that exercise TTL / sleep paths (Cache, Metrics histogram
+    time, ...) fail with `Time_compat: clock not initialized` because
+    [set_clock] is normally only called inside [Kirin.run], which the test
+    runner never invokes. *)
+let with_eio f () = Eio_main.run @@ fun env ->
+  Kirin.Time_compat.set_clock (Eio.Stdenv.clock env);
+  f ()
 
 (** Alcotest re-exports for convenience *)
 let test_case = test_case


### PR DESCRIPTION
## Why

Three test cases (`Cache ttl`, `Cache cleanup`, `Metrics histogram time`) fail consistently on every CI run with:

```
Time_compat: clock not initialized. Call Time_compat.set_clock during Eio.main before using sleep.
```

Root cause: those tests call `Kirin.Time_compat.sleep` (or `.now`), which reads a *global* Eio clock that is normally seeded by `Kirin.run` via `Time_compat.set_clock` (`lib/server.ml:171`). The test runner enters `Alcotest.run` directly without going through `Kirin.run`, so the global stays unset. The test split in #72 surfaced this — the previous monolithic `test_kirin.ml` happened to wrap time-dependent paths inside a single `Eio_main.run`/`Kirin.run` flow.

## Change

`test/test_helpers.ml` — `with_eio` already wraps test bodies in `Eio_main.run`. Extend it to call `Kirin.Time_compat.set_clock (Eio.Stdenv.clock env)` before invoking the body. `set_clock` is a plain ref write, so re-setting per test is harmless and isolation-safe under Alcotest's sequential runner.

```ocaml
let with_eio f () = Eio_main.run @@ fun env ->
  Kirin.Time_compat.set_clock (Eio.Stdenv.clock env);
  f ()
```

No production code touched. No test bodies touched.

## Verification

- Local `dune build` clean.
- Local `dune test` — **210 tests run, all green** (previous 3 flakes clear).

## Out of scope (for follow-up)

- `ocaml-webrtc.0.2.6` ubuntu opam install failure in the CI matrix is a separate issue (different repo, system dep). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
