### PR TITLE
test: replace Unix.sleepf with Eio.Time.sleep (closes #75)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -109,7 +109,7 @@
 
 (test
  (name test_trace)
- (libraries kirin alcotest hmap unix))
+ (libraries kirin alcotest hmap eio eio_main))
 
 (test
  (name test_no_shell_node_worker)
@@ -118,7 +118,7 @@
 
 (test
  (name test_cache)
- (libraries kirin alcotest eio_main unix))
+ (libraries kirin alcotest eio eio_main))
 
 (test
  (name test_pool)

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -71,18 +71,18 @@ let basic_tests = [
 (* -- TTL expiry ---------------------------------------------------- *)
 
 let test_ttl_expiry () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let cache = Kirin.Cache.create ~max_size:10 () in
   Kirin.Cache.set ~ttl:0.0 cache "short" "val";
-  Unix.sleepf 0.01;
+  Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
   let result = Kirin.Cache.get cache "short" in
   check (option string) "expired" None result
 
 let test_default_ttl () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let cache = Kirin.Cache.create ~max_size:10 ~default_ttl:0.0 () in
   Kirin.Cache.set cache "k" "v";
-  Unix.sleepf 0.01;
+  Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
   let result = Kirin.Cache.get cache "k" in
   check (option string) "default ttl expired" None result
 
@@ -93,10 +93,10 @@ let test_no_ttl_never_expires () =
   check (option string) "still here" (Some "here") (Kirin.Cache.get cache "forever")
 
 let test_per_entry_ttl_overrides_default () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let cache = Kirin.Cache.create ~max_size:10 ~default_ttl:3600.0 () in
   Kirin.Cache.set ~ttl:0.0 cache "short" "val";
-  Unix.sleepf 0.01;
+  Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
   check (option string) "per-entry ttl expired" None (Kirin.Cache.get cache "short")
 
 let ttl_tests = [
@@ -176,12 +176,12 @@ let test_clear () =
   check (option string) "a gone" None (Kirin.Cache.get cache "a")
 
 let test_cleanup () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let cache = Kirin.Cache.create ~max_size:10 () in
   Kirin.Cache.set ~ttl:0.0 cache "expired1" "v";
   Kirin.Cache.set ~ttl:0.0 cache "expired2" "v";
   Kirin.Cache.set cache "alive" "v";
-  Unix.sleepf 0.01;
+  Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
   let removed = Kirin.Cache.cleanup cache in
   check int "2 cleaned" 2 removed;
   check int "1 remaining" 1 (Kirin.Cache.size cache)

--- a/test/test_health_suite.ml
+++ b/test/test_health_suite.ml
@@ -55,8 +55,9 @@ let test_health_ready_control () =
   check bool "ready again" true (H.is_ready health)
 
 let test_health_uptime () =
+  Eio_main.run @@ fun env ->
   let health = H.create () in
-  Unix.sleepf 0.01;
+  Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
   let _, json = H.check health in
   let uptime = match json with
     | `Assoc fields ->

--- a/test/test_trace.ml
+++ b/test/test_trace.ml
@@ -48,8 +48,9 @@ let test_set_error () =
   check bool "now error" true (span.status = `Error "timeout")
 
 let test_duration () =
+  Eio_main.run @@ fun env ->
   let span = Kirin.Trace.start ~name:"op" () in
-  Unix.sleepf 0.01;
+  Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
   Kirin.Trace.finish span;
   let dur = Kirin.Trace.duration span in
   check bool "duration > 0" true (dur > 0.0);


### PR DESCRIPTION
## Why

Issue #75 tracks `Unix.sleepf` in test code. `Unix.sleepf` blocks the OS thread, which is wrong in Eio test contexts — it should yield via Eio's scheduler so other fibers can run.

## Change

6 call sites swapped to `Eio.Time.sleep (Eio.Stdenv.clock env) 0.01`:

| File | Sites | Strategy |
|---|---|---|
| `test/test_cache.ml` | 4 | tests already had `Eio_main.run @@ fun _env ->` — captured `env` and used `Eio.Stdenv.clock env`. Dropped now-unused `unix` lib. |
| `test/test_health_suite.ml` | 1 | wrapped `test_health_uptime` in `Eio_main.run`. Group already has `eio_main`. |
| `test/test_trace.ml` | 1 | wrapped `test_duration` in `Eio_main.run`. Replaced `unix` lib with `eio eio_main`. |

No production code touched.

## Verification

```
$ dune build       # clean
$ dune runtest     # 207 pass, 3 pre-existing fail (PR #82 fixes those — Cache ttl, Cache cleanup, Metrics histogram)
```

The 3 failures are unchanged by this PR — they exist in `test_cache_suite.ml` / `test_metrics_suite.ml` (different files), surfaced by the test-split in PR #72, and are fixed by PR #82's `test_helpers.ml` `set_clock` addition.

## Scope

- Closes the `test/` portion of #75. No production `Unix.sleepf` usage in repo.
- Does not depend on PR #82 — independent fix path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)