### PR TITLE
feat(mcp/transport): optional clock+timeout for HTTP send paths (refs #77)

### DIFF
--- a/lib/mcp/transport.ml
+++ b/lib/mcp/transport.ml
@@ -152,25 +152,38 @@ let is_streamable_http = function
     and blocks the current fiber until the response arrives via
     [resolve_pending_request].
 
-    The [Promise.await] call here has no explicit timeout.  This is safe
-    because Eio's structured concurrency guarantees that all fibers
-    spawned inside a [Switch.run] scope are cancelled when the switch
-    exits (whether normally or via exception).  Callers that need a
-    wall-clock deadline should wrap the call in [Eio.Time.with_timeout]. *)
-let send_http_request (t : streamable_http_transport) (request : Jsonrpc.request) =
+    When [clock] and [timeout] are both provided, [Promise.await] is wrapped
+    in [Eio.Time.with_timeout]. On expiry the pending entry is deregistered
+    (so a late response cannot resolve a stale resolver) and
+    [Transport_error] is raised.
+
+    Without [clock]/[timeout] the await is unbounded: it relies on the
+    enclosing [Eio.Switch] being cancelled to release. Callers running
+    outside a bounded switch must pass an explicit deadline. *)
+let send_http_request ?clock ?timeout (t : streamable_http_transport) (request : Jsonrpc.request) =
   let promise, resolver = Promise.create () in
   register_pending_request t request.id resolver;
   Stream.add t.message_queue (Jsonrpc.Request request);
-  Promise.await promise
+  match clock, timeout with
+  | Some clk, Some sec ->
+    (match Eio.Time.with_timeout clk sec (fun () -> Ok (Promise.await promise)) with
+     | Ok v -> v
+     | Error `Timeout ->
+       t.pending_requests <- List.remove_assoc request.id t.pending_requests;
+       raise (Transport_error
+                (Printf.sprintf "MCP HTTP request timed out after %.1fs" sec)))
+  | _, _ -> Promise.await promise
 
 (** Send a request and wait for response.
     For stdio: writes the request and reads responses until a matching ID arrives.
-    For HTTP: queues the request and awaits a Promise resolved by the HTTP handler. *)
-let send_request transport request =
+    For HTTP: queues the request and awaits a Promise resolved by the HTTP handler.
+
+    [clock]/[timeout] are forwarded to [send_http_request] for HTTP transports.
+    They are ignored for stdio (line-based read; no Eio scheduling primitive). *)
+let send_request ?clock ?timeout transport request =
   match transport with
   | Stdio { ic; oc } ->
     write_message_stdio oc (Jsonrpc.Request request);
-    (* Read responses until we get one matching our id *)
     let rec wait_for_response () =
       match read_message_stdio ic with
       | Jsonrpc.Response resp when resp.id = request.id -> resp
@@ -178,7 +191,7 @@ let send_request transport request =
     in
     wait_for_response ()
   | Streamable_http t ->
-    send_http_request t request
+    send_http_request ?clock ?timeout t request
 
 (** Send a notification (no response expected) *)
 let send_notification transport notif =

--- a/lib/mcp/transport.mli
+++ b/lib/mcp/transport.mli
@@ -37,8 +37,25 @@ val endpoint : t -> string option
 val is_stdio : t -> bool
 val is_streamable_http : t -> bool
 val send_http_request :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout:float ->
   streamable_http_transport ->
   Jsonrpc.request -> Jsonrpc.response
+(** Send an HTTP MCP request and await its response.
+
+    Pass [~clock] and [~timeout] together to bound the await with
+    [Eio.Time.with_timeout]; on expiry the pending entry is deregistered and
+    [Transport_error "MCP HTTP request timed out after Ns"] is raised.
+
+    Omitting either keeps the historical unbounded await — release relies on
+    the enclosing [Eio.Switch] being cancelled. Code paths that may run
+    outside a bounded switch should always pass both. *)
+
 val send_request :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout:float ->
   t -> Jsonrpc.request -> Jsonrpc.response
+(** Send a request on either transport. [clock]/[timeout] apply to HTTP only;
+    stdio is line-based and ignores them. *)
+
 val send_notification : t -> Jsonrpc.notification -> unit

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -852,6 +852,27 @@ let test_transport_queue_on_stdio_fails () =
   | exception Tr.Transport_error _ -> ()
   | _ -> fail "expected Transport_error"
 
+let test_transport_send_http_request_timeout () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let t = match Tr.of_streamable_http () with
+    | Tr.Streamable_http x -> x
+    | Tr.Stdio _ -> fail "expected Streamable_http"
+  in
+  let req = J.make_request ~id:(J.Int 1) ~method_:"test/nop" () in
+  let before = List.length t.pending_requests in
+  match Tr.send_http_request ~clock ~timeout:0.05 t req with
+  | exception Tr.Transport_error msg ->
+    check bool "error mentions timeout"
+      true
+      (String.length msg > 0
+       && (try let _ = Str.search_forward (Str.regexp_string "timed out") msg 0 in true
+           with Not_found -> false));
+    check int "pending entry deregistered after timeout"
+      before
+      (List.length t.pending_requests)
+  | _ -> fail "expected Transport_error after timeout"
+
 let transport_tests = [
   test_case "stdio create" `Quick test_transport_stdio_create;
   test_case "streamable http create" `Quick test_transport_streamable_http_create;
@@ -859,6 +880,8 @@ let transport_tests = [
   test_case "session id streamable" `Quick test_transport_session_id_streamable;
   test_case "queue message streamable" `Quick test_transport_queue_message_streamable;
   test_case "queue on stdio fails" `Quick test_transport_queue_on_stdio_fails;
+  test_case "send_http_request timeout deregisters pending"
+    `Quick test_transport_send_http_request_timeout;
 ]
 
 (** {1 Client Tests} *)


### PR DESCRIPTION
## Why

Issue #77 medium finding: \`send_http_request\` (\`lib/mcp/transport.ml:150-164\`) does \`Promise.await\` with no built-in deadline. The existing doc-comment punted to callers (\"wrap in \`Eio.Time.with_timeout\` yourself\"), which is exactly the API-misuse smell #77 flags.

Outside an enclosing \`Eio.Switch\` that may cancel, the fiber hangs forever. The pending request also accumulates in \`t.pending_requests\` until the transport is dropped.

## Change

Add **optional** \`?clock\` + \`?timeout\` to \`send_http_request\` and \`send_request\`. When both are passed, the await is bounded by \`Eio.Time.with_timeout\`. On expiry:
1. Pending entry is removed from \`t.pending_requests\` (a late server response cannot resolve a stale resolver).
2. \`Transport_error \"MCP HTTP request timed out after Ns\"\` is raised.

Omitting either parameter keeps the historical unbounded await — **zero breaking changes** to existing call sites in \`lib/mcp/client.ml\` (8 sites) and \`lib/mcp_adapter.ml\` (1 site). Future client refactor can plumb clock/timeout through.

Stdio path ignores \`clock\`/\`timeout\` — it is line-based blocking read with no Eio scheduling primitive to interrupt. (Out of scope for this PR.)

## Verification

\`\`\`
$ dune build       # clean
$ dune exec test/test_mcp.exe   # 78 tests run, all green
\`\`\`

New test: \`Transport 6 — send_http_request timeout deregisters pending\`. Schedules a request with no resolver, \`timeout=0.05s\`, asserts \`Transport_error\` is raised and the pending list returns to its pre-call size.

## Out of scope (for follow-up)

- Plumb \`clock\`/\`timeout\` through \`lib/mcp/client.ml\` so high-level client calls (\`call_tool\`, \`list_resources\`, etc.) accept deadlines.
- Stdio timeout (would require non-blocking read with Eio scheduling).
- Other Issue #77 findings: \`lib/svelte/handler.ml\` and \`lib/solid/handler.ml\` placeholder route-context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)