### PR TITLE
fix(svelte,solid): thread route params from Request (refs #77)

### DIFF
--- a/lib/solid/handler.ml
+++ b/lib/solid/handler.ml
@@ -84,8 +84,7 @@ let page_handler ~options req =
 (** Data loader handler *)
 let data_handler ~options:_ ~loader req =
   let url = Kirin.Request.path req in
-  (* Note: params are extracted by Kirin's router and available via Request.param *)
-  let params = [] in  (* TODO: Get from route context when available *)
+  let params = req.Kirin.Request.params in
   match loader ~url ~params with
   | Router.Data data ->
     Kirin.Response.json (`Assoc [

--- a/lib/solid/handler.mli
+++ b/lib/solid/handler.mli
@@ -13,7 +13,8 @@ val page_handler : options:options -> Kirin.Request.t -> Kirin.Response.t
 val data_handler :
   options:'a ->
   loader:(url:string ->
-          params:'b list -> Yojson.Safe.t Router.loader_result) ->
+          params:Kirin.Request.params ->
+          Yojson.Safe.t Router.loader_result) ->
   Kirin.Request.t -> Kirin.Response.t
 val health_handler : options:options -> 'a -> Kirin.Response.t
 val is_vite_request : string -> bool
@@ -22,7 +23,7 @@ val routes : options:options -> Kirin.Router.route list
 val data_routes :
   loaders:(string *
            (url:string ->
-            params:'a list ->
+            params:Kirin.Request.params ->
             Yojson.Safe.t Router.loader_result))
           list ->
   Kirin.Router.route list

--- a/lib/solid/kirin_solid.mli
+++ b/lib/solid/kirin_solid.mli
@@ -81,7 +81,7 @@ val routes : options:Handler.options -> Kirin.Router.route list
 val data_routes :
   loaders:(string *
            (url:string ->
-            params:'a list ->
+            params:Kirin.Request.params ->
             Yojson.Safe.t Router.loader_result))
           list ->
   Kirin.Router.route list

--- a/lib/svelte/handler.ml
+++ b/lib/svelte/handler.ml
@@ -86,7 +86,7 @@ let page_handler ~options req =
 (** Data loader handler for +page.server.ts style loading *)
 let load_handler ~loader req =
   let url = Kirin.Request.path req in
-  let params = [] in  (* TODO: Extract from route context *)
+  let params = req.Kirin.Request.params in
 
   let ctx = Loader.create_context
     ~url ~params ~route_id:url


### PR DESCRIPTION
## Why

Issue #77 medium finding: \`svelte/handler.ml:89\` and \`solid/handler.ml:88\` both hard-coded \`params = []\` with a TODO. The router *already* stores matched path segments in \`Request.params\`. Other adapters (\`react/protocol.ml\`, \`astro/protocol.ml\`, \`preact/protocol.ml\`) read \`req.params\` directly — Svelte/Solid were the only stragglers.

Consequence: every Svelte \`+page.server.ts\` loader and every Solid \`data_handler\` ran with empty params. Dynamic routes like \`/posts/[id]\` silently dropped the \`id\` segment before reaching user code.

## Change

\`\`\`diff
-  let params = [] in  (* TODO: Get from route context when available *)
+  let params = req.Kirin.Request.params in
\`\`\`

Two call sites. Plus two .mli updates in solid — the previous signatures used \`params:'b list\` (over-general), which is exactly why the bug compiled. Tightening to \`params:Kirin.Request.params\` (= \`(string * string) list\`) makes future regressions a type error.

## Verification

\`\`\`
$ dune build       # clean
$ dune exec test/test_svelte.exe   # 99 tests pass
$ dune exec test/test_solid.exe    # exit 0
\`\`\`

Runtime test suites for these adapters don't exercise dynamic routes today (the prior \`params = []\` meant there was nothing to verify), so this PR adds no new test. A route-context integration test belongs in a follow-up that exercises the full router→handler→loader path.

## Out of scope

- Issue #77's MCP transport timeout finding — PR #84.
- The same \`params = []\` placeholder appears in several \`codegen.ml\` files (angular/vue/qwik/etc.) — those are codegen templates, not runtime handlers; touched only if/when their adapters wire data routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)