### PR TITLE
feat(mcp/client): per-client default clock+timeout (follows #84)

### DIFF
--- a/lib/mcp/client.ml
+++ b/lib/mcp/client.ml
@@ -6,12 +6,23 @@
 
 (** {1 Types} *)
 
-(** MCP Client *)
+(** MCP Client.
+
+    [default_clock] and [default_timeout] are forwarded to
+    [Transport.send_request] on every request. When both are set, the HTTP
+    transport bounds the [Promise.await] with [Eio.Time.with_timeout] and
+    deregisters the pending entry on expiry (raises [Transport_error]).
+
+    Omitting either keeps the historical unbounded await — clients running
+    outside a cancelling [Eio.Switch] should always pass both at construction
+    time. *)
 type t = {
   transport : Transport.t;
   mutable server_capabilities : Protocol.server_capabilities option;
   mutable server_info : Protocol.implementation_info option;
   mutable request_id : int;
+  default_clock : float Eio.Time.clock_ty Eio.Resource.t option;
+  default_timeout : float option;
 }
 
 (** Client error *)
@@ -19,13 +30,20 @@ exception Client_error of string
 
 (** {1 Constructor} *)
 
-(** Create a client connected to a transport *)
-let create transport =
+(** Create a client connected to a transport.
+
+    Pass [?clock] + [?timeout] to install a per-client deadline that applies
+    to every HTTP request the client makes. Per-call override is not yet
+    exposed at the helper layer — use [Transport.send_request] directly or
+    wrap the call in [Eio.Time.with_timeout] for fine-grained control. *)
+let create ?clock ?timeout transport =
   {
     transport;
     server_capabilities = None;
     server_info = None;
     request_id = 0;
+    default_clock = clock;
+    default_timeout = timeout;
   }
 
 (** {1 Request ID Generation} *)
@@ -38,11 +56,21 @@ let next_id t =
 
 (** {1 Low-Level Communication} *)
 
-(** Send a request and wait for response *)
+(** Send a request and wait for response.
+
+    Forwards the client's [default_clock]/[default_timeout] to
+    [Transport.send_request]. When both are set on the client and the
+    transport is HTTP, the await is bounded — on expiry a
+    [Transport.Transport_error] is raised (not [Client_error]). *)
 let send_request t ~method_ ?params () =
   let id = next_id t in
   let request = Jsonrpc.make_request ~id ~method_ ?params () in
-  let response = Transport.send_request t.transport request in
+  let response =
+    Transport.send_request
+      ?clock:t.default_clock
+      ?timeout:t.default_timeout
+      t.transport request
+  in
   match response.error with
   | Some err ->
     raise (Client_error (Printf.sprintf "RPC error %d: %s"

--- a/lib/mcp/client.mli
+++ b/lib/mcp/client.mli
@@ -4,9 +4,22 @@ type t = {
     Protocol.server_capabilities option;
   mutable server_info : Protocol.implementation_info option;
   mutable request_id : int;
+  default_clock : float Eio.Time.clock_ty Eio.Resource.t option;
+  default_timeout : float option;
 }
 exception Client_error of string
-val create : Transport.t -> t
+
+val create :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?timeout:float ->
+  Transport.t -> t
+(** Create an MCP client.
+
+    Pass [~clock] and [~timeout] together to bound every HTTP request issued
+    through this client; on expiry the underlying transport raises
+    [Transport.Transport_error]. Omitting either keeps the historical
+    unbounded await. *)
+
 val next_id : t -> Jsonrpc.id
 val send_request :
   t ->

--- a/lib/mcp/kirin_mcp.mli
+++ b/lib/mcp/kirin_mcp.mli
@@ -17,5 +17,8 @@ val create_server :
   ?version:string ->
   ?log_level:Logging.log_level ->
   ?log_handler:(Logging.log_message -> unit) -> unit -> Server.t
-val create_client : Transport.t -> Client.t
+val create_client :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?timeout:float ->
+  Transport.t -> Client.t
 val version : string

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -919,10 +919,29 @@ let test_client_next_id_monotonic () =
   in
   check bool "100 IDs strictly increasing" true (is_sorted ints)
 
+let test_client_create_with_deadline_fields_set () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let transport = Tr.of_streamable_http () in
+  let client = C.create ~clock ~timeout:2.5 transport in
+  check bool "default_clock set" true (Option.is_some client.C.default_clock);
+  check (option (float 0.0001)) "default_timeout set" (Some 2.5) client.C.default_timeout
+
+let test_client_create_no_deadline_defaults_to_none () =
+  Eio_main.run @@ fun _env ->
+  let transport = Tr.of_streamable_http () in
+  let client = C.create transport in
+  check bool "default_clock None" true (Option.is_none client.C.default_clock);
+  check (option (float 0.0001)) "default_timeout None" None client.C.default_timeout
+
 let client_tests = [
   test_case "create" `Quick test_client_create;
   test_case "next_id" `Quick test_client_next_id;
   test_case "next_id monotonic" `Quick test_client_next_id_monotonic;
+  test_case "create with deadline fields set" `Quick
+    test_client_create_with_deadline_fields_set;
+  test_case "create without deadline defaults to None" `Quick
+    test_client_create_no_deadline_defaults_to_none;
 ]
 
 (** {1 Governance Tests} *)


### PR DESCRIPTION
## Why

PR #84 added optional \`clock\`+\`timeout\` to \`Transport.send_http_request\`/\`send_request\` but **no caller passes them**. The 8 high-level helpers in \`Client\` (\`initialize\`, \`list_tools\`, \`call_tool\`, ...) all call \`send_request t\` without forwarding deadline info — so the feature is invisible to actual users.

This closes the loop: an MCP client built outside a cancelling \`Eio.Switch\` will hang forever on an unresponsive server, even though the transport plumbing is now in place.

## Change

\`Client.create\` accepts optional \`?clock\` + \`?timeout\`. Stored on the record; \`send_request\` forwards them to \`Transport.send_request\` on every call.

\`\`\`ocaml
val create :
  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
  ?timeout:float ->
  Transport.t -> t
\`\`\`

The 8 helpers are unchanged. Existing callers (\`Client.create transport\`, no extra args) keep the historical unbounded behavior — zero breaking changes. The single migration step for production code is at the construction site:

\`\`\`diff
- let client = Client.create transport in
+ let client = Client.create ~clock:(Eio.Stdenv.clock env) ~timeout:30.0 transport in
\`\`\`

When both args are set and transport is HTTP, an unresponsive server triggers \`Transport.Transport_error\` after the configured deadline. The pending request is deregistered (PR #84 guarantee), so subsequent calls aren't affected.

## Verification

\`\`\`
$ dune build       # clean
$ dune exec test/test_mcp.exe   # 80 tests (78 prior + 2 new)
\`\`\`

New tests:
- \`Client 3: create with deadline fields set\` — \`~clock ~timeout:2.5\` lands on the record
- \`Client 4: create without deadline defaults to None\` — backward compat
- End-to-end timeout-on-stale-server is covered by PR #84's transport-level \`Transport 6\` test.

## Out of scope

- Per-call override of the client default (callers must use the client default or call \`Transport.send_request\` directly with overrides).
- Mapping \`Transport.Transport_error\` to \`Client_error\` at the helper layer (intentional: timeout is a transport concern, not protocol concern; mixing them obscures the failure source).
- Updating client constructors in \`mcp_adapter.ml\` to pass clock/timeout — that touches integration points and belongs in a separate PR with explicit deadline policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)