### PR TITLE
feat(jobs): try_submit returning Result on queue full

### DIFF
--- a/lib/jobs.ml
+++ b/lib/jobs.ml
@@ -240,44 +240,66 @@ let create
 
 (** {1 Job Submission} *)
 
+(** Internal: atomic check-then-insert under the queue mutex.
+    Returns [Error `Queue_full] when capacity is reached so [submit] and
+    [try_submit] can share the same critical section without racing the
+    [is_full] check against the actual insert. *)
+let do_submit_locked ?priority ?max_retries t task =
+  let priority = Option.value ~default:Normal priority in
+  let max_retries = Option.value ~default:t.config.default_max_retries max_retries in
+  Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+    if List.length t.jobs >= t.config.max_queue_size then
+      Error `Queue_full
+    else begin
+      let id =
+        let n = t.next_id in
+        t.next_id <- n + 1;
+        Printf.sprintf "job_%d_%d" n (int_of_float (Eio.Time.now t.clock *. 1000.0))
+      in
+      let job = {
+        id;
+        task;
+        priority;
+        status = Pending;
+        retries = 0;
+        max_retries;
+        created_at = Eio.Time.now t.clock;
+        started_at = None;
+        completed_at = None;
+      } in
+      t.jobs <- insert_by_priority job t.jobs;
+      Hashtbl.replace t.results job.id Pending;
+      t.stats <- {
+        t.stats with
+        total_submitted = t.stats.total_submitted + 1;
+        queue_size = t.stats.queue_size + 1;
+      };
+      Eio.Condition.broadcast t.job_available;
+      Ok job.id
+    end
+  )
+
 (** Submit a job to the queue.
 
     @param priority Job priority (default: Normal)
     @param max_retries Maximum retry attempts (default: config value)
     @return Job ID for tracking
+    @raise Failure when the queue is at [max_queue_size]
 *)
 let submit ?priority ?max_retries t task =
-  let priority = Option.value ~default:Normal priority in
-  let max_retries = Option.value ~default:t.config.default_max_retries max_retries in
-  Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
-    if List.length t.jobs >= t.config.max_queue_size then
-      failwith "Job queue full";
-    let id =
-      let n = t.next_id in
-      t.next_id <- n + 1;
-      Printf.sprintf "job_%d_%d" n (int_of_float (Eio.Time.now t.clock *. 1000.0))
-    in
-    let job = {
-      id;
-      task;
-      priority;
-      status = Pending;
-      retries = 0;
-      max_retries;
-      created_at = Eio.Time.now t.clock;
-      started_at = None;
-      completed_at = None;
-    } in
-    t.jobs <- insert_by_priority job t.jobs;
-    Hashtbl.replace t.results job.id Pending;
-    t.stats <- {
-      t.stats with
-      total_submitted = t.stats.total_submitted + 1;
-      queue_size = t.stats.queue_size + 1;
-    };
-    Eio.Condition.broadcast t.job_available;
-    job.id
-  )
+  match do_submit_locked ?priority ?max_retries t task with
+  | Ok id -> id
+  | Error `Queue_full -> failwith "Job queue full"
+
+(** Submit a job, returning [Error `Queue_full] instead of raising when the
+    queue is at capacity. Use this in request paths and producer loops where
+    queue saturation is a recoverable condition (apply backpressure, return
+    503, drop low-priority work, etc.).
+
+    The single critical section guarantees the capacity check and the
+    insert are atomic — no TOCTOU window between [is_full] and [submit]. *)
+let try_submit ?priority ?max_retries t task =
+  do_submit_locked ?priority ?max_retries t task
 
 let submit_all ?priority ?max_retries t tasks =
   List.map (submit ?priority ?max_retries t) tasks

--- a/lib/jobs.mli
+++ b/lib/jobs.mli
@@ -111,6 +111,17 @@ val create :
     @raise Failure if the queue is full *)
 val submit : ?priority:priority -> ?max_retries:int -> 'a t -> (unit -> 'a) -> job_id
 
+(** [try_submit ?priority ?max_retries t task] submits a job, returning
+    [Error `Queue_full] instead of raising when the queue is at capacity.
+
+    The capacity check and the enqueue happen in a single mutex critical
+    section, so there is no TOCTOU window between a separate [is_full]
+    check and the [submit] call. Use this in request paths and producer
+    loops where saturation is a recoverable condition. *)
+val try_submit :
+  ?priority:priority -> ?max_retries:int -> 'a t -> (unit -> 'a) ->
+  (job_id, [> `Queue_full ]) result
+
 (** [submit_all ?priority ?max_retries t tasks] submits multiple jobs. *)
 val submit_all : ?priority:priority -> ?max_retries:int -> 'a t -> (unit -> 'a) list -> job_id list
 

--- a/test/test_jobs_suite.ml
+++ b/test/test_jobs_suite.ml
@@ -87,6 +87,38 @@ let test_jobs_priority () =
   check int "all queued" 3 stats.queue_size;
   J.stop queue
 
+let test_jobs_try_submit_ok () =
+  with_eio_jobs @@ fun ~sw ~clock ->
+  let queue = J.create ~sw ~clock ~workers:2 () in
+  (match J.try_submit queue (fun () -> "x") with
+   | Ok id -> check bool "got id" true (String.length id > 0)
+   | Error `Queue_full -> fail "fresh queue should not be full");
+  J.stop queue
+
+let test_jobs_try_submit_queue_full () =
+  with_eio_jobs @@ fun ~sw ~clock ->
+  (* Tiny capacity. Workers=0 ensures nothing drains during the test. *)
+  let queue = J.create ~sw ~clock ~workers:0 ~max_queue_size:2 () in
+  (match J.try_submit queue (fun () -> "a") with
+   | Ok _ -> ()
+   | Error `Queue_full -> fail "1st submit should succeed");
+  (match J.try_submit queue (fun () -> "b") with
+   | Ok _ -> ()
+   | Error `Queue_full -> fail "2nd submit should succeed");
+  (match J.try_submit queue (fun () -> "c") with
+   | Ok _ -> fail "3rd submit should be rejected"
+   | Error `Queue_full -> ());
+  J.stop queue
+
+let test_jobs_submit_still_raises_when_full () =
+  with_eio_jobs @@ fun ~sw ~clock ->
+  let queue = J.create ~sw ~clock ~workers:0 ~max_queue_size:1 () in
+  let _ = J.submit queue (fun () -> "x") in
+  (match J.submit queue (fun () -> "y") with
+   | _ -> fail "submit should raise on full queue"
+   | exception Failure _ -> ());
+  J.stop queue
+
 let tests = [
   test_case "jobs create" `Quick test_jobs_create;
   test_case "jobs submit" `Quick test_jobs_submit;
@@ -97,4 +129,8 @@ let tests = [
   test_case "jobs cancel" `Quick test_jobs_cancel;
   test_case "jobs clear" `Quick test_jobs_clear;
   test_case "jobs priority" `Quick test_jobs_priority;
+  test_case "jobs try_submit ok" `Quick test_jobs_try_submit_ok;
+  test_case "jobs try_submit queue full" `Quick test_jobs_try_submit_queue_full;
+  test_case "jobs submit still raises when full" `Quick
+    test_jobs_submit_still_raises_when_full;
 ]


### PR DESCRIPTION
## Why

\`Jobs.submit\` raises \`Failure \"Job queue full\"\` at capacity — same ergonomic problem PR #87 just fixed for \`Pool.map\`. A request handler or producer loop that wants to apply backpressure (return 503, drop low-priority work, retry with delay) must either:

1. Probe queue size externally → TOCTOU race against another producer's \`submit\`.
2. \`try Jobs.submit … with Failure _\` → catches too broadly, fragile to message-string changes.

Saturation is a recoverable condition. The API should let callers express that.

## Change

Add \`try_submit\` returning \`(job_id, [> \\`Queue_full ]) result\`:

\`\`\`ocaml
val try_submit :
  ?priority:priority -> ?max_retries:int -> 'a t -> (unit -> 'a) ->
  (job_id, [> \`Queue_full ]) result
\`\`\`

Both \`submit\` and \`try_submit\` share an internal \`do_submit_locked\` helper. The capacity check and the enqueue happen in the **same mutex critical section** — no TOCTOU window. \`submit\` keeps raising for back-compat.

This mirrors the pattern PR #87 established in \`Pool\` and the existing \`param\`/\`param_opt\` split in \`Request\`.

## Verification

\`\`\`
$ dune build       # clean
$ dune exec test/test_kirin.exe   # 213 tests (210 prior + 3 new), all green
\`\`\`

3 new tests:
- \`Jobs 9: try_submit ok\` — fresh queue returns \`Ok id\`.
- \`Jobs 10: try_submit queue full\` — capacity=2 + workers=0, 3rd submit returns \`Error \\`Queue_full\`.
- \`Jobs 11: submit still raises when full\` — back-compat guard, ensures the existing API contract is preserved.

## Out of scope

- Migrating internal callers (none today — only test/example code uses Jobs.submit).
- Result-returning \`status\`/\`wait\`/\`run_once\` (they raise on unknown job_id — different smell, separate scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)