### PR TITLE
feat(jobs): try_status / try_wait returning Result on Unknown_job

### DIFF
--- a/lib/jobs.ml
+++ b/lib/jobs.ml
@@ -284,12 +284,17 @@ let submit_all ?priority ?max_retries t tasks =
 
 (** {1 Job Status} *)
 
-let status t job_id =
+let try_status t job_id =
   Eio.Mutex.use_ro t.mutex (fun () ->
     match Hashtbl.find_opt t.results job_id with
-    | Some s -> s
-    | None -> failwith ("Unknown job: " ^ job_id)
+    | Some s -> Ok s
+    | None -> Error `Unknown_job
   )
+
+let status t job_id =
+  match try_status t job_id with
+  | Ok s -> s
+  | Error `Unknown_job -> failwith ("Unknown job: " ^ job_id)
 
 let is_complete t job_id =
   match status t job_id with
@@ -297,8 +302,9 @@ let is_complete t job_id =
   | Pending | Running -> false
 
 (** Wait for a job to complete. Suspends the current fiber without blocking
-    OS threads. *)
-let wait t job_id =
+    OS threads. Returns [Error `Unknown_job] without entering the wait loop
+    if the id is not known — callers cannot deadlock on a typo. *)
+let try_wait t job_id =
   let rec loop () =
     let st =
       Eio.Mutex.use_ro t.mutex (fun () ->
@@ -306,15 +312,20 @@ let wait t job_id =
       )
     in
     match st with
-    | Some (Completed _ as s) | Some (Failed _ as s) -> s
+    | Some (Completed _ as s) | Some (Failed _ as s) -> Ok s
     | Some Pending | Some Running ->
       Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
         Eio.Condition.await t.job_completed t.mutex
       );
       loop ()
-    | None -> failwith ("Unknown job: " ^ job_id)
+    | None -> Error `Unknown_job
   in
   loop ()
+
+let wait t job_id =
+  match try_wait t job_id with
+  | Ok s -> s
+  | Error `Unknown_job -> failwith ("Unknown job: " ^ job_id)
 
 (** {1 Queue Control} *)
 

--- a/lib/jobs.mli
+++ b/lib/jobs.mli
@@ -120,6 +120,12 @@ val submit_all : ?priority:priority -> ?max_retries:int -> 'a t -> (unit -> 'a) 
     @raise Failure if job_id is unknown *)
 val status : 'a t -> job_id -> 'a status
 
+(** [try_status t job_id] returns the current status, or [Error `Unknown_job]
+    if the id is not in the results table. Use this when callers should
+    tolerate a typoed or stale id without crashing. *)
+val try_status :
+  'a t -> job_id -> ('a status, [> `Unknown_job ]) result
+
 (** [is_complete t job_id] returns [true] if the job has completed or failed. *)
 val is_complete : 'a t -> job_id -> bool
 
@@ -127,6 +133,12 @@ val is_complete : 'a t -> job_id -> bool
     Suspends the current fiber without blocking OS threads.
     @raise Failure if job_id is unknown *)
 val wait : 'a t -> job_id -> 'a status
+
+(** [try_wait t job_id] waits for a job to complete, returning
+    [Error `Unknown_job] without entering the wait loop if the id is
+    unknown — callers cannot deadlock on a typo. *)
+val try_wait :
+  'a t -> job_id -> ('a status, [> `Unknown_job ]) result
 
 (** {1 Queue Control} *)
 

--- a/test/test_jobs_suite.ml
+++ b/test/test_jobs_suite.ml
@@ -87,6 +87,37 @@ let test_jobs_priority () =
   check int "all queued" 3 stats.queue_size;
   J.stop queue
 
+let test_jobs_try_status_known_and_unknown () =
+  with_eio_jobs @@ fun ~sw ~clock ->
+  let queue = J.create ~sw ~clock ~workers:2 () in
+  let id = J.submit queue (fun () -> 42) in
+  (match J.try_status queue id with
+   | Ok _ -> ()
+   | Error `Unknown_job -> fail "known job_id should not be Unknown_job");
+  (match J.try_status queue "bogus_id" with
+   | Ok _ -> fail "bogus id should not return Ok"
+   | Error `Unknown_job -> ());
+  J.stop queue
+
+let test_jobs_try_wait_known_and_unknown () =
+  with_eio_jobs @@ fun ~sw ~clock ->
+  let queue = J.create ~sw ~clock ~workers:2 () in
+  let id = J.submit queue (fun () -> "done") in
+  (match J.try_wait queue id with
+   | Ok (J.Completed "done") -> ()
+   | Ok other ->
+       fail (Printf.sprintf "unexpected status: %s"
+               (match other with
+                | J.Pending -> "Pending"
+                | J.Running -> "Running"
+                | J.Completed _ -> "Completed(other)"
+                | J.Failed _ -> "Failed"))
+   | Error `Unknown_job -> fail "known job_id should not be Unknown_job");
+  (match J.try_wait queue "bogus_id" with
+   | Ok _ -> fail "bogus id should not return Ok"
+   | Error `Unknown_job -> ());
+  J.stop queue
+
 let tests = [
   test_case "jobs create" `Quick test_jobs_create;
   test_case "jobs submit" `Quick test_jobs_submit;
@@ -97,4 +128,8 @@ let tests = [
   test_case "jobs cancel" `Quick test_jobs_cancel;
   test_case "jobs clear" `Quick test_jobs_clear;
   test_case "jobs priority" `Quick test_jobs_priority;
+  test_case "jobs try_status known and unknown" `Quick
+    test_jobs_try_status_known_and_unknown;
+  test_case "jobs try_wait known and unknown" `Quick
+    test_jobs_try_wait_known_and_unknown;
 ]


### PR DESCRIPTION
## Why

\`Jobs.status\` and \`Jobs.wait\` raise \`Failure \"Unknown job: <id>\"\` when asked about an id that is not (or no longer) in the results table. Same ergonomic problem PR #87 (Pool.map) and PR #88 (Jobs.submit) just fixed:

- Background supervisor loops probing a slate of expected ids must \`try Jobs.status … with Failure _\` — overly broad, tied to a literal error message.
- \`Jobs.wait\` is the dangerous one: a typoed id only fails *after* the function enters its condition-variable loop, but reads the missing entry on the first iteration and raises immediately. Still — a Result return saves the caller from a fiber crash on a stale supervisor-key.
- Stale ids from external sources (request headers, DB rows, cache keys) crash request-handling fibers instead of falling through to a 404 / not-found path.

## Change

\`\`\`ocaml
val try_status : 'a t -> job_id -> ('a status, [> \`Unknown_job ]) result
val try_wait   : 'a t -> job_id -> ('a status, [> \`Unknown_job ]) result
\`\`\`

Both \`status\` and \`wait\` are kept as thin wrappers that pattern-match the \`try_*\` result and raise on \`Error\` — same back-compat strategy used in PR #88 for \`submit\` / \`try_submit\`. Single source of truth for the lookup logic.

\`is_complete\` keeps its raising contract (it is a derived predicate on \`status\`; a \`try_is_complete\` would force callers to handle \`Result of Result\` semantics — separate scope, defer until a caller actually needs it).

## Verification

\`\`\`
$ dune build       # clean
$ dune exec test/test_kirin.exe   # 212 tests (210 prior + 2 new)
\`\`\`

New tests:
- \`Jobs 9: try_status known and unknown\` — \`Ok status\` for a real id, \`Error \\`Unknown_job\` for \"bogus_id\".
- \`Jobs 10: try_wait known and unknown\` — same path, but exercises the wait-then-return-status case.

## Pattern continuity

This is the third repeat of the \`fn\` / \`try_fn\` idiom in the kirin tree this iteration cycle:

| PR | Module | Raising | Result variant | Error tag |
|---|---|---|---|---|
| #87 | Parallel.Pool | map / iter / reduce | try_map / try_iter / try_reduce | \`Pool_shutdown\` |
| #88 | Jobs | submit | try_submit | \`Queue_full\` |
| this | Jobs | status / wait | try_status / try_wait | \`Unknown_job\` |

At three sites the pattern is an *idiom*; a fourth site should probably skip the manual repeat and consider a generic \`Try.lift\` helper. Not yet — but worth noting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)