### PR TITLE
feat(parallel): try_race returning Result on empty task list

### DIFF
--- a/lib/parallel.ml
+++ b/lib/parallel.ml
@@ -187,13 +187,28 @@ let all tasks =
     let first_result = (List.hd tasks) () in
     first_result :: List.map Domain.join spawned
 
-(** Run computations and return first to complete (racing) *)
+(** Run computations and return first to complete (racing), or
+    [Error `Empty_task_list] if the input is empty.
+
+    Single Atomic-like guarantee: the emptiness check happens before
+    [all] spawns any Domains, so callers passing a possibly-empty list
+    pay no scheduling cost on the empty path. *)
+let try_race tasks =
+  match tasks with
+  | [] -> Stdlib.Error `Empty_task_list
+  | _ ->
+    (* This is a simplified implementation; a full one would need
+       cancellation. *)
+    Stdlib.Ok (List.hd (all tasks))
+
+(** Run computations and return first to complete (racing).
+    @raise Failure on an empty task list. Use [try_race] to handle that
+    case explicitly. *)
 let race tasks =
-  (* Note: This is a simplified implementation.
-     A full implementation would need cancellation support. *)
-  match all tasks with
-  | [] -> failwith "Parallel.race: empty task list"
-  | results -> List.hd results
+  match try_race tasks with
+  | Stdlib.Ok v -> v
+  | Stdlib.Error `Empty_task_list ->
+    failwith "Parallel.race: empty task list"
 
 (** {1 Domain Pool} *)
 

--- a/lib/parallel.mli
+++ b/lib/parallel.mli
@@ -56,8 +56,15 @@ val triple : (unit -> 'a) -> (unit -> 'b) -> (unit -> 'c) -> 'a * 'b * 'c
 (** [all tasks] runs a list of computations in parallel. *)
 val all : (unit -> 'a) list -> 'a list
 
-(** [race tasks] runs computations and returns the first result. *)
+(** [race tasks] runs computations and returns the first result.
+    @raise Failure on an empty task list. *)
 val race : (unit -> 'a) list -> 'a
+
+(** [try_race tasks] returns [Error `Empty_task_list] instead of raising
+    when [tasks] is empty. Use this when the caller cannot statically
+    guarantee a non-empty list. *)
+val try_race :
+  (unit -> 'a) list -> ('a, [> `Empty_task_list ]) Stdlib.result
 
 (** {1 Domain Pool} *)
 

--- a/test/test_parallel_suite.ml
+++ b/test/test_parallel_suite.ml
@@ -65,6 +65,22 @@ let test_parallel_recommended () =
   let n = P.recommended_domains () in
   check bool "at least 1 domain" true (n >= 1)
 
+let test_parallel_try_race_nonempty () =
+  match P.try_race [(fun () -> 42)] with
+  | Ok 42 -> ()
+  | Ok n -> fail (Printf.sprintf "unexpected result %d" n)
+  | Error `Empty_task_list -> fail "nonempty list should not be Empty_task_list"
+
+let test_parallel_try_race_empty () =
+  match P.try_race [] with
+  | Ok _ -> fail "empty list should not return Ok"
+  | Error `Empty_task_list -> ()
+
+let test_parallel_race_still_raises_on_empty () =
+  match P.race [] with
+  | _ -> fail "race should raise on empty"
+  | exception Failure _ -> ()
+
 let tests = [
   test_case "parallel map" `Quick test_parallel_map;
   test_case "parallel iter" `Quick test_parallel_iter;
@@ -75,4 +91,8 @@ let tests = [
   test_case "parallel pool" `Quick test_parallel_pool;
   test_case "parallel chunk_list" `Quick test_parallel_chunk_list;
   test_case "parallel recommended" `Quick test_parallel_recommended;
+  test_case "try_race nonempty" `Quick test_parallel_try_race_nonempty;
+  test_case "try_race empty" `Quick test_parallel_try_race_empty;
+  test_case "race still raises on empty" `Quick
+    test_parallel_race_still_raises_on_empty;
 ]


### PR DESCRIPTION
## Why

\`Parallel.race\` raises \`Failure \"Parallel.race: empty task list\"\` when the input is empty. Same ergonomic problem as PR #87 (Pool.map), #88 (Jobs.submit), #89 (Jobs.status/wait): callers wanting graceful handling of the empty case must \`try Parallel.race … with Failure _\` — overly broad, tied to a literal error message.

## Change

\`\`\`ocaml
val try_race :
  (unit -> 'a) list -> ('a, [> \`Empty_task_list ]) Stdlib.result
\`\`\`

\`race\` is a thin wrapper that raises only on the \`Error\` path. Single source of truth for the spawn logic. Backward-compatible — existing \`race\` callers unaffected.

The emptiness check happens *before* \`all\` spawns any Domains — empty inputs are O(1) and cause no scheduler work.

## Stdlib.result qualification

This module defines its own \`type 'a result = Ok of 'a | Error of exn\` that shadows the prelude (same situation as PR #87). Signatures use \`Stdlib.result\` explicitly; the implementation uses \`Stdlib.Ok\` / \`Stdlib.Error\`.

## Verification

\`\`\`
\$ dune build       # clean
\$ dune exec test/test_kirin.exe   # 213 tests (210 prior + 3 new)
\`\`\`

3 new tests:
- \`Parallel 9: try_race nonempty\` — \`Ok 42\` from a one-task list.
- \`Parallel 10: try_race empty\` — \`Error \\`Empty_task_list\`.
- \`Parallel 11: race still raises on empty\` — back-compat guard.

## Pattern continuity

This is the fourth iteration of the \`fn\` / \`try_fn\` idiom in kirin:

| PR | Module | Function(s) | Error tag |
|---|---|---|---|
| #87 | Parallel.Pool | map / iter / reduce | \`Pool_shutdown\` |
| #88 | Jobs | submit | \`Queue_full\` |
| #89 | Jobs | status / wait | \`Unknown_job\` |
| this | Parallel | race | \`Empty_task_list\` |

At four sites the idiom is well-established. Worth noting as a candidate for a future RFC: a generic \`Total.lift : (unit -> 'a) -> ('a, exn) result\` for *all* partial functions, or a \`#[partial]\` attribute that auto-generates the try_* variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)