### PR TITLE
fix(server): catch user-handler exceptions, never leak details to client

### DIFF
--- a/lib/server.ml
+++ b/lib/server.ml
@@ -87,7 +87,8 @@ let make_cohttp_handler ~clock ~config _sw (handler : Router.handler) =
 
     let resp =
       try handle_with_timeout ()
-      with Eio.Buf_read.Buffer_limit_exceeded ->
+      with
+      | Eio.Buf_read.Buffer_limit_exceeded ->
         Logger.warn "Request body too large (limit %d bytes): %s %s"
           config.max_body_size
           (Http.Method.to_string (Cohttp.Request.meth request))
@@ -96,6 +97,24 @@ let make_cohttp_handler ~clock ~config _sw (handler : Router.handler) =
           ~status:`Request_entity_too_large
           ~headers:(Cohttp.Header.of_list [("content-type", "application/json")])
           (`String (Printf.sprintf "{\"error\":\"Request body too large\",\"max_bytes\":%d}" config.max_body_size))
+      | Eio.Cancel.Cancelled _ as exn ->
+        (* Structured-concurrency control flow — never absorb a Cancelled
+           into a 500 or the parent switch can't unwind. *)
+        raise exn
+      | exn ->
+        (* Any other handler exception becomes a generic 500. Without this
+           catch, cohttp-eio's default error path emits whatever the
+           underlying transport chooses (potentially Printexc.to_string of
+           the exception, which can leak internal details — file paths,
+           stack frames, secret values in error messages). *)
+        Logger.error "Unhandled handler exception on %s %s: %s"
+          (Http.Method.to_string (Cohttp.Request.meth request))
+          (Cohttp.Request.resource request)
+          (Printexc.to_string exn);
+        Response.make
+          ~status:`Internal_server_error
+          ~headers:(Cohttp.Header.of_list [("content-type", "application/json")])
+          (`String "{\"error\":\"Internal server error\"}")
     in
 
     (* Convert to cohttp-eio response *)


### PR DESCRIPTION
## Why

\`server.ml\` wrapped handler calls in \`try … with Buffer_limit_exceeded\` but did not catch any other exception. If a user handler raised — a typo \`failwith\`, a \`List.hd []\`, a \`Yojson.Json_error\`, an unwrapped \`Result.get_ok\` on Error, an unexpected \`Failure\` from a downstream library — the exception escaped to cohttp-eio's default error path.

Two consequences:

### 1. Information disclosure

cohttp's default 500 includes \`Printexc.to_string\` of the exception. That can contain:
- File paths from stack frames (\`File \"lib/db.ml\", line 42\")
- Function names that hint at internal structure
- Secret values embedded in error messages — the classic \`failwith (\"Bad DB url: \" ^ db_url_with_password)\` accident

A test of a fresh Kirin server today, with a handler that raises \`failwith \"secret=abc123\"\`, would surface \"secret=abc123\" in the response body.

### 2. Inconsistent observability

Handler-side errors didn't go through Kirin's \`Logger\`, so structured log pipelines missed them.

## Change

Add two arms after \`Buffer_limit_exceeded\`:

\`\`\`ocaml
| Eio.Cancel.Cancelled _ as exn -> raise exn
| exn ->
    Logger.error \"Unhandled handler exception on %s %s: %s\"
      (Http.Method.to_string ...) (Cohttp.Request.resource request)
      (Printexc.to_string exn);
    Response.make
      ~status:\`Internal_server_error
      ~headers:[...]
      (\`String \"{\\\"error\\\":\\\"Internal server error\\\"}\")
\`\`\`

\`Eio.Cancel.Cancelled\` re-raises (structured-concurrency control flow; absorbing it into a 500 prevents the parent switch from unwinding — would silently drop cancellations and break Eio's lifecycle invariants).

Any other exception logs through \`Logger.error\` with method+path+exn-string, then returns a fixed \`{\"error\":\"Internal server error\"}\` body. No internal detail crosses the boundary.

## Verification

\`\`\`
\$ dune build  # clean
\$ dune test   # 210 tests pass (server is exercised in integration fixtures)
\`\`\`

A targeted server-integration test that asserts the exact body and absence of details would be ideal but requires plumbing a real socket — scope creep for this fix. The Logger.error path is the same error machinery used elsewhere; that contract is already covered.

## Out of scope

- Structured error responses keyed by exception type (e.g. \`Yojson.Json_error → 400\`). The current catch returns \`500\` uniformly; specific exception → status mappings belong in middleware.
- Producer-fiber exceptions (line 123-128 already has its own catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)