### PR TITLE
feat(auth/oauth2): try_parse_tokens / try_parse_user_info on Result

### DIFF
--- a/lib/auth/oauth2.ml
+++ b/lib/auth/oauth2.ml
@@ -134,7 +134,13 @@ let authorization_url ?(scope = []) ?(state = generate_state ())
 
 (** {1 Token Exchange} *)
 
-(** Parse token response *)
+(** Parse token response.
+
+    OAuth2 provider responses are external input — a misbehaving provider
+    or an error response in an unexpected shape can leave [access_token]
+    missing or wrong-typed, which would [Yojson.Safe.Util.Type_error] out
+    of [to_string]. Use [try_parse_tokens] in any caller that wants a
+    structured failure instead of an escaping exception. *)
 let parse_tokens json =
   let open Yojson.Safe.Util in
   {
@@ -145,6 +151,12 @@ let parse_tokens json =
     scope = json |> member "scope" |> to_string_option;
     id_token = json |> member "id_token" |> to_string_option;
   }
+
+(** Result-returning variant of [parse_tokens]. Returns [Error msg] for
+    a missing/non-string [access_token] or any other unexpected JSON shape. *)
+let try_parse_tokens json =
+  try Ok (parse_tokens json)
+  with Yojson.Safe.Util.Type_error (msg, _) -> Error msg
 
 (** Exchange authorization code for tokens (blocking, needs HTTP client) *)
 let exchange_code_params provider code =
@@ -207,6 +219,13 @@ let parse_user_info (provider : provider) json =
          json |> member "picture" |> to_string_option)
   in
   { id; email; name = user_name; picture; raw = json }
+
+(** Result-returning variant of [parse_user_info]. Provider responses with
+    a missing/non-string [id] (or non-int for GitHub) become [Error msg]
+    instead of escaping as [Type_error]. *)
+let try_parse_user_info provider json =
+  try Ok (parse_user_info provider json)
+  with Yojson.Safe.Util.Type_error (msg, _) -> Error msg
 
 (** {1 PKCE Support} *)
 

--- a/lib/auth/oauth2.mli
+++ b/lib/auth/oauth2.mli
@@ -53,10 +53,23 @@ val authorization_url :
   ?state:string ->
   ?extra_params:(string * string) list -> provider -> string * string
 val parse_tokens : Yojson__Safe.t -> tokens
+(** @raise Yojson.Safe.Util.Type_error on missing/non-string [access_token]. *)
+
+val try_parse_tokens : Yojson__Safe.t -> (tokens, string) result
+(** Result-returning variant. Use in any path where the provider response
+    is not statically guaranteed to be well-formed. *)
+
 val exchange_code_params : provider -> string -> (string * string) list
 val token_request_body : provider -> string -> string
 val refresh_token_params : provider -> string -> (string * string) list
+
 val parse_user_info : provider -> Yojson__Safe.t -> user_info
+(** @raise Yojson.Safe.Util.Type_error on missing/wrong-typed [id]
+    (or non-int [id] for GitHub). *)
+
+val try_parse_user_info : provider -> Yojson__Safe.t -> (user_info, string) result
+(** Result-returning variant. *)
+
 val generate_code_verifier : unit -> string
 val generate_code_challenge : String.t -> string
 val authorization_url_pkce :


### PR DESCRIPTION
## Why

\`oauth2.ml\`'s \`parse_tokens\` and \`parse_user_info\` use \`Yojson.Safe.Util.to_string\` on external JSON inputs (OAuth2 provider responses). A misbehaving provider — wrong field type, error response in a different shape, mid-rotation API change — raises \`Type_error\` out of both functions.

PR #91 catches such escapes at the server boundary, but the trust boundary for OAuth2 parsing is the auth module itself. Same idiom established by PR #92 for \`jwt.decode\`: keep the raising variant for back-compat, add a \`try_*\` variant that returns \`Error\`.

## Change

\`\`\`ocaml
val try_parse_tokens    : Yojson.Safe.t -> (tokens, string) result
val try_parse_user_info : provider -> Yojson.Safe.t -> (user_info, string) result
\`\`\`

Both wrap the raising variant in a single \`try/with Yojson.Safe.Util.Type_error -> Error\`. The exception message becomes the \`Error\` payload — non-leaky because \`Type_error.message\` is constructed from field paths and a fixed reason, not from input bytes.

## Verification

\`\`\`
\$ dune build       # clean
\$ dune test        # 210 + auth tests pass
\`\`\`

## Pattern continuity

This is the **fifth** \`fn\` / \`try_fn\` PR in kirin:

| PR | Module | Error tag |
|---|---|---|
| #87 | Parallel.Pool | \`Pool_shutdown\` |
| #88 | Jobs.submit | \`Queue_full\` |
| #89 | Jobs.status/wait | \`Unknown_job\` |
| #90 | Parallel.race | \`Empty_task_list\` |
| #92 | Auth.Jwt.decode | (string) |
| this | Auth.OAuth2 (×2) | (string) |

At five+ sites the idiom is firmly established. The next addition should probably be RFC-level — a generic \`Total.lift\` helper, a \`[@@partial]\` attribute that auto-generates the \`try_*\` variant, or a documented module template. Hand-writing the wrapper at each site is fine for now but starting to feel like the right scope for a small RFC.

## Out of scope

- A property-based test that throws random JSON at the parsers.
- Tightening the error type from \`string\` to a typed variant like \`[\\`Missing_field of string | \\`Wrong_type of string]\` (the \`Type_error\` payload already carries that info; routing it through a typed variant is a larger ergonomics change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)