### PR TITLE
sec(mcp_adapter): re-raise Cancelled, stop leaking Printexc to clients

### DIFF
--- a/lib/mcp_adapter.ml
+++ b/lib/mcp_adapter.ml
@@ -202,10 +202,19 @@ let routes ?(prefix = "/mcp") ~ctx (server : Server.t) : Router.route list =
         ~message:(Printf.sprintf "JSON parse error: %s" msg) () in
       let resp = Jsonrpc.error_response ~id:Jsonrpc.Null error in
       Response.json (Jsonrpc.encode_response resp)
+    | Eio.Cancel.Cancelled _ as e ->
+      (* Cancellation is structured-concurrency control flow, not an
+         application error. Absorbing it into an Internal_error response
+         prevents the parent switch from unwinding. *)
+      raise e
     | e ->
+      (* Log the underlying exception server-side; never leak its
+         message (which may contain file paths, stack frames, or secret
+         values embedded in error strings) to the JSON-RPC client. *)
+      Logger.error "MCP handler exception: %s" (Printexc.to_string e);
       let error = Jsonrpc.make_error
         ~code:Jsonrpc.Internal_error
-        ~message:(Printexc.to_string e) () in
+        ~message:"Internal error" () in
       let resp = Jsonrpc.error_response ~id:Jsonrpc.Null error in
       Response.json (Jsonrpc.encode_response resp)
   in


### PR DESCRIPTION
## Why

\`handle_post\` in \`mcp_adapter.ml\` had a catch-all \`| e -> ...\` arm with two defects:

### 1. Absorbed \`Eio.Cancel.Cancelled\`

\`Eio.Cancel.Cancelled\` is **structured-concurrency control flow**, not an application error. The pre-fix code converted it into an \`Internal_error\` JSON-RPC response and returned. That pins the fiber to the request lifecycle and breaks the parent switch's teardown: cancelled switches expect children to propagate \`Cancelled\` so cleanup runs.

### 2. Information disclosure

\`message: Printexc.to_string e\` lands in the JSON-RPC response. Exception messages commonly contain file paths, stack-frame names, or secret values embedded in failure strings (the classic \`failwith (\"Bad DB url: \" ^ db_url_with_password)\` accident).

PR #91 fixed the same class of leak at the cohttp server boundary. This is the in-handler twin — the leak would have surfaced *before* PR #91's outer catch could rewrite the response.

## Change

Three small additions to the existing \`try/with\`:

\`\`\`ocaml
| Eio.Cancel.Cancelled _ as e -> raise e
| e ->
    Logger.error \"MCP handler exception: %s\" (Printexc.to_string e);
    let error = Jsonrpc.make_error
      ~code:Jsonrpc.Internal_error
      ~message:\"Internal error\" () in
    ...
\`\`\`

- \`Cancelled\` re-raises so the switch can unwind.
- Underlying exception logs server-side via \`Logger.error\`.
- Client sees the fixed string \`\"Internal error\"\` with the existing \`Internal_error\` JSON-RPC code — category is still observable, internals are not.

## Verification

\`\`\`
\$ dune build       # clean
\$ dune exec test/test_mcp.exe   # 78 tests, all green
\`\`\`

## Out of scope

- Same pattern audit in other adapters (\`graphql_adapter\`, \`webrtc_signaling\`, etc.). Inspection in this audit showed those don't use \`Printexc.to_string\` in client-facing messages and have specific \`Type_error\` arms — they're OK.
- Structured error responses (e.g., mapping specific exceptions to error codes). The current fix is a uniform \`Internal_error\` — fine for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)