### PR TITLE
sec(qwik,astro/protocol): stop leaking Printexc messages to clients

### DIFF
--- a/lib/astro/protocol.ml
+++ b/lib/astro/protocol.ml
@@ -112,7 +112,8 @@ let decode_response s =
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e ->
-    Error { id = 0; code = parse_error; message = Printexc.to_string e; data = None }
+    Kirin.Logger.error "astro decode_response exception: %s" (Printexc.to_string e);
+    Error { id = 0; code = parse_error; message = "Worker response parse error"; data = None }
 
 (** {1 Response Construction} *)
 

--- a/lib/qwik/protocol.ml
+++ b/lib/qwik/protocol.ml
@@ -114,7 +114,8 @@ let decode_response str =
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e ->
-    Failure { id = 0; code = -32700; message = Printexc.to_string e }
+    Kirin.Logger.error "qwik decode_response exception: %s" (Printexc.to_string e);
+    Failure { id = 0; code = -32700; message = "Worker response parse error" }
 
 (** {1 Health Check} *)
 
@@ -148,7 +149,8 @@ let decode_batch str =
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e ->
-    [Failure { id = 0; code = -32700; message = Printexc.to_string e }]
+    Kirin.Logger.error "qwik decode_batch exception: %s" (Printexc.to_string e);
+    [Failure { id = 0; code = -32700; message = "Worker batch response parse error" }]
 
 (** {1 Serialization} *)
 


### PR DESCRIPTION
## Why

Same pattern PR #94 fixed in \`mcp_adapter\`: the catch-all arm in three protocol \`decode_*\` functions put \`Printexc.to_string e\` into the response \`message\` field. Three sites:

| File | Function | Line |
|---|---|---|
| \`lib/qwik/protocol.ml\` | \`decode_response\` | 117 |
| \`lib/qwik/protocol.ml\` | \`decode_batch\` | 151 |
| \`lib/astro/protocol.ml\` | \`decode_response\` | 115 |

These messages are \`Failure\` / \`Error\` variants of the worker-protocol result type, and they bubble up through the adapter into the JSON sent to the client. An exception during decode (corrupted worker output, \`Yojson.Type_error\` from an unexpected response shape, \`Failure\` from an upstream library) lands its OCaml-flavored description on the wire — file paths, function names, sometimes embedded secret values.

## Change

Uniformly:
- Log the underlying exception via \`Kirin.Logger.error\` (server-side observable).
- Return a fixed \`\"Worker response parse error\"\` / \`\"Worker batch response parse error\"\` message.

The protocol code (\`-32700\`) still identifies \"parse error\" to the client; only the internal representation is now redacted.

The \`Eio.Cancel.Cancelled\` re-raise arms were already in place in both files — no change there.

## Verification

\`\`\`
\$ dune build       # clean
\$ dune test        # all green
\`\`\`

## Out of scope

- Other adapters not flagged in this audit (\`angular\`, \`vue\`, \`react\`, \`svelte\`, \`solid\`, etc.) — inspection during this PR showed their protocol decode functions don't use \`Printexc.to_string\` in client-facing messages. If a future audit finds another instance, same fix applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)