### PR TITLE
sec(tanstack/handler): redact exception in default error handler

### DIFF
--- a/lib/tanstack/handler.ml
+++ b/lib/tanstack/handler.ml
@@ -17,11 +17,18 @@ type config = {
 let default_not_found _req =
   Response.html ~status:`Not_found "<h1>404 Not Found</h1>"
 
-(** Default error handler *)
+(** Default error handler. Logs the exception server-side and returns a
+    fixed-body 500. Older versions embedded [Printexc.to_string exn] in the
+    response body, which exposed internal file paths, stack-frame names,
+    and any secret values that happened to be in the exception message —
+    a classic accidental information-disclosure default.
+
+    Applications that want detailed error pages during development should
+    construct a debug handler explicitly via [config.error_handler]. *)
 let default_error_handler exn _req =
+  Kirin.Logger.error "tanstack handler exception: %s" (Printexc.to_string exn);
   Response.html ~status:`Internal_server_error
-    (Printf.sprintf "<h1>500 Internal Server Error</h1><pre>%s</pre>"
-       (Printexc.to_string exn))
+    "<h1>500 Internal Server Error</h1>"
 
 (** Default config *)
 let default_config manifest = {


### PR DESCRIPTION
## Why

\`Tanstack.Handler.default_error_handler\` embedded \`Printexc.to_string exn\` inside a \`<pre>...</pre>\` block in the 500 response body:

\`\`\`ocaml
let default_error_handler exn _req =
  Response.html ~status:\`Internal_server_error
    (Printf.sprintf \"<h1>500 Internal Server Error</h1><pre>%s</pre>\"
       (Printexc.to_string exn))
\`\`\`

An application that uses the default (forgets to set \`config.error_handler\`) ships with a debug-mode-like error page in production. The HTML body exposes:

- File paths from stack frames (\`File \"lib/db.ml\", line 42, ...\`)
- OCaml function/module names
- Any secret values embedded in failure strings (\`failwith (\"Bad DB url: \" ^ db_url_with_password)\`)

Secure default is the principle: an application that does nothing should be safe by default; opting in to verbose diagnostics is the user's explicit choice.

## Change

\`\`\`ocaml
let default_error_handler exn _req =
  Kirin.Logger.error \"tanstack handler exception: %s\" (Printexc.to_string exn);
  Response.html ~status:\`Internal_server_error
    \"<h1>500 Internal Server Error</h1>\"
\`\`\`

Server-side log still has the full \`Printexc.to_string\` payload — operators can debug from logs. The client sees only the category (500 + a fixed heading).

Docstring updated to point users at \`config.error_handler\` for dev-time verbose mode.

## Pattern continuity

Same info-disclosure family the recent audit closed:

| PR | Layer |
|---|---|
| #91 | Server-level (cohttp default error path) |
| #92 | Auth JWT decode |
| #94 | MCP adapter catch-all |
| #95 | Qwik / Astro protocol decode |
| this | Tanstack default error handler |

## Verification

\`\`\`
\$ dune build  # clean
\$ dune test   # tanstack tests pass
\`\`\`

## Out of scope

- A documented \`debug_error_handler\` in tanstack for opt-in dev use — could be a follow-up if there's demand.
- Same audit across other framework adapters' \`config.error_handler\` defaults (none found in the same shape during this pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)