### PR TITLE
sec(auth/password): use CSPRNG /dev/urandom for password salt

### DIFF
--- a/lib/auth/password.ml
+++ b/lib/auth/password.ml
@@ -24,13 +24,20 @@ let hash_length = 32
 
 (** {1 Helpers} *)
 
-(** Generate random salt using SHA256 of timestamp + random *)
+(** Generate a cryptographically random salt.
+
+    Previous implementation hashed [Unix.gettimeofday] + [Random.int] +
+    [Unix.getpid] — all predictable inputs. [Random] is Mersenne Twister
+    (not a CSPRNG) and only seeded by [Random.self_init], which mixes
+    in weak entropy. The result was a salt with limited effective
+    entropy that an attacker could approximate by guessing the second
+    and PID, enabling precomputed rainbow-table attacks against the
+    password column even though the values *looked* random.
+
+    [Secure_random.random_string] reads directly from [/dev/urandom],
+    which is the kernel CSPRNG with full system-entropy backing. *)
 let generate_salt () =
-  let now = Unix.gettimeofday () in
-  let rand = Random.int 1_000_000_000 in
-  let entropy = Printf.sprintf "salt-%.6f-%d-%d" now rand (Unix.getpid ()) in
-  let hash = Digestif.SHA256.digest_string entropy in
-  String.sub (Digestif.SHA256.to_raw_string hash) 0 salt_length
+  Secure_random.random_string salt_length
 
 (** Bytes to hex string *)
 let bytes_to_hex bytes =


### PR DESCRIPTION
## Why

\`Password.generate_salt\` was composing its salt from three **predictable** inputs:

\`\`\`ocaml
let generate_salt () =
  let now = Unix.gettimeofday () in            (* microsecond resolution, narrow window *)
  let rand = Random.int 1_000_000_000 in       (* Mersenne Twister, NOT a CSPRNG *)
  let entropy = Printf.sprintf \"salt-%.6f-%d-%d\" now rand (Unix.getpid ()) in
  ...
  SHA256.digest_string entropy ...
\`\`\`

SHA256 of these inputs *looks* random but the **input space is tractable**:

- \`gettimeofday\` for a known user is bounded by their account-creation timestamp (often public).
- \`Random.int\` is Mersenne Twister; without strong seeding by something *other than the same predictable inputs*, the state is recoverable.
- \`Unix.getpid\` is bounded by the OS PID range (Linux default \`< 32768\`).

An attacker with the user's signup timestamp and a few PID guesses can **enumerate the full salt space**, then run a targeted rainbow-table attack on that user's password hash — exactly what salts are designed to prevent.

## Change

\`\`\`ocaml
let generate_salt () = Secure_random.random_string salt_length
\`\`\`

\`Secure_random\` (already in this module, used by \`Session.generate_id\` and \`OAuth2.generate_state\`) reads directly from \`/dev/urandom\` — the kernel CSPRNG with full system-entropy backing. This makes \`generate_salt\` the last non-CSPRNG random source in the auth module.

## Backward compatibility

Salt length unchanged (32 bytes). Existing password hashes in databases remain valid — \`verify_password\` reads the stored salt and feeds it back through PBKDF2 as before. **Only newly hashed passwords** benefit from the stronger salt. No migration needed.

## Verification

\`\`\`
\$ dune build  # clean
\$ dune exec test/test_auth.exe   # 30 tests pass
\`\`\`

The \`Password\` test cases exercise the hash/verify roundtrip with the new generator. They wouldn't fail with the old implementation — the bug is in *entropy quality*, not correctness — so the regression value here is mostly making sure I didn't break the API shape.

## Out of scope

- Bump iteration count of PBKDF2 default — separate hardening concern.
- Switch to Argon2id — bigger change, requires opam dep and migration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)