### PR TITLE
sec(webrtc_adapter): unguessable peer_id from /dev/urandom

### DIFF
--- a/lib/webrtc_adapter.ml
+++ b/lib/webrtc_adapter.ml
@@ -121,6 +121,35 @@ let create_answer peer ~remote_sdp =
 
 (** {1 HTTP/WebSocket Handlers} *)
 
+(** Read [n] cryptographically random bytes from /dev/urandom and encode
+    as lowercase hex. Used for routing identifiers (peer_id, room_id)
+    that an attacker must not be able to predict or front-run.
+
+    Avoids depending on the auth sub-library (which is sibling) by
+    inlining the same /dev/urandom read pattern Secure_random uses. *)
+let random_hex n =
+  let buf = Bytes.create n in
+  let fd = Unix.openfile "/dev/urandom" [Unix.O_RDONLY] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close fd)
+    (fun () ->
+       let rec loop off =
+         if off < n then
+           let r = Unix.read fd buf off (n - off) in
+           if r <= 0 then failwith "webrtc_adapter: short read from /dev/urandom"
+           else loop (off + r)
+       in
+       loop 0);
+  let hex = Bytes.create (n * 2) in
+  let to_hex x = if x < 10 then Char.chr (x + Char.code '0')
+                 else Char.chr (x - 10 + Char.code 'a') in
+  Bytes.iteri (fun i c ->
+    let b = Char.code c in
+    Bytes.set hex (i * 2) (to_hex (b lsr 4));
+    Bytes.set hex (i * 2 + 1) (to_hex (b land 0xf))
+  ) buf;
+  Bytes.to_string hex
+
 (** Create signaling server WebSocket handler.
     Use with Kirin.websocket for signaling. *)
 let signaling_handler () =
@@ -129,7 +158,11 @@ let signaling_handler () =
     if not (Websocket.is_upgrade_request req) then
       Response.make ~status:`Bad_request (`String "Expected WebSocket upgrade")
     else
-      let peer_id = Printf.sprintf "peer_%d" (Random.int 100000) in
+      (* 12 random bytes = 24 hex chars = 96 bits of entropy. Birthday-
+         collision probability is negligible up to ~2^48 simultaneous
+         peers, and an attacker cannot guess the next peer_id from the
+         previous one (no Mersenne Twister state to recover). *)
+      let peer_id = "peer_" ^ random_hex 12 in
       let room_id = Request.query "room" req |> Option.value ~default:"default" in
       Signaling.join_room server ~room_id ~peer_id;
       match Websocket.upgrade_response req with


### PR DESCRIPTION
## Why

\`signaling_handler\` assigned peer IDs via:

\`\`\`ocaml
let peer_id = Printf.sprintf \"peer_%d\" (Random.int 100000) in
\`\`\`

Two security issues:

### 1. Mersenne Twister is not a CSPRNG

\`Random\` is OCaml's Mersenne Twister. State is recoverable from 624 observed outputs. An attacker who connects once observes \`peer_<N>\` in the \`X-Peer-Id\` response, recovers MT state, then predicts the next \`peer_id\` for unrelated clients.

### 2. 100 000-element output space

Birthday collision at \`~sqrt(100_000) ≈ 317\` simultaneous connections. Two distinct sessions ending up with the same \`peer_id\` lets one observe/inject signaling messages destined for the other.

### Concrete attack

A malicious client connects, observes its assigned \`peer_id\`, recovers MT state, predicts the *next* \`peer_id\`. It then sends a forged offer/answer/ICE-candidate addressed *as* that predicted peer to the signaling server. The next real client to connect gets that \`peer_id\` and immediately receives the malicious payload, enabling MITM on the WebRTC handshake.

## Change

Inline \`random_hex\` that reads from \`/dev/urandom\` (same primitive \`Auth.Secure_random\` uses; inlined here to avoid pulling \`kirin\` into a sibling-library dependency cycle).

\`\`\`ocaml
let peer_id = \"peer_\" ^ random_hex 12   (* 96 bits entropy, 24 hex chars *)
\`\`\`

- Birthday collision negligible to \`~2^48\` simultaneous peers.
- Forward prediction infeasible — no PRNG state to recover.

## Verification

\`\`\`
\$ dune build  # clean
\$ dune test   # 210 tests pass
\`\`\`

## Pattern continuity

Same \`Random.\` → CSPRNG family as PR #97 (auth/password salt). Both came from the same audit pass.

| PR | Module | Fix |
|---|---|---|
| #97 | auth/password salt | Mersenne Twister + gettimeofday → /dev/urandom |
| this | webrtc peer_id | Mersenne Twister → /dev/urandom |

\`lib/trace.ml\` also uses \`Random\` but explicitly comments \"Not for cryptographic purposes\" — left as-is (trace_id/span_id correlation is not a security boundary).

## Out of scope

- Promoting the inline \`random_hex\` helper into a main-lib module so both \`webrtc_adapter\` and other future security-relevant identifier sites can share it. Doable as a follow-up RFC if a third site appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)