### PR TITLE
fix(webrtc_signaling): take server.mutex when looking up rooms

### DIFF
--- a/lib/webrtc_signaling.ml
+++ b/lib/webrtc_signaling.ml
@@ -127,15 +127,24 @@ let join_room server ~room_id ~peer_id =
   Eio.Mutex.use_rw ~protect:true room.mutex (fun () ->
     Hashtbl.replace room.peers peer_id ())
 
+(** Take the server.rooms Hashtbl lookup under server.mutex so it cannot
+    race a concurrent [get_or_create_room] insertion. Return the room
+    handle (which has its own mutex) outside the server-lock so the
+    server critical section stays short — subsequent room.peers access
+    uses room.mutex, no nested locking. *)
+let find_room server room_id =
+  Eio.Mutex.use_ro server.mutex (fun () ->
+    Hashtbl.find_opt server.rooms room_id)
+
 let leave_room server ~room_id ~peer_id =
-  match Hashtbl.find_opt server.rooms room_id with
+  match find_room server room_id with
   | None -> ()
   | Some room ->
     Eio.Mutex.use_rw ~protect:true room.mutex (fun () ->
       Hashtbl.remove room.peers peer_id)
 
 let get_peers server room_id =
-  match Hashtbl.find_opt server.rooms room_id with
+  match find_room server room_id with
   | None -> []
   | Some room ->
     Eio.Mutex.use_ro room.mutex (fun () ->


### PR DESCRIPTION
## Why

\`leave_room\` and \`get_peers\` were reading \`server.rooms\` via \`Hashtbl.find_opt\` **without holding \`server.mutex\`**. \`get_or_create_room\` inserts into the same \`server.rooms\` Hashtbl *under* \`server.mutex\`. Concurrent invocations race on the Hashtbl internals.

Eio's default single-domain scheduler is cooperative — plain \`Hashtbl.find_opt\` doesn't yield mid-call, so single-domain deployments don't trip this race. But kirin servers can run multiple Domains (\`Server.start\` / \`cluster.ml\` use \`Domain.spawn\`). Across domains:

- Hashtbl is not thread-safe.
- A concurrent insert that triggers a resize can leave the bucket array in an inconsistent state visible to the concurrent reader.
- Result: \`Hashtbl.find_opt\` reads a half-resized bucket, possibly seeing stale data or, with bad luck, segfaulting.

## Change

Extract \`find_room\` that takes \`server.mutex\` for the lookup:

\`\`\`ocaml
let find_room server room_id =
  Eio.Mutex.use_ro server.mutex (fun () ->
    Hashtbl.find_opt server.rooms room_id)
\`\`\`

\`leave_room\` and \`get_peers\` both call \`find_room\` first. The room's *own* mutex (\`room.mutex\`) still covers \`room.peers\` access, so no nested locking — server's critical section stays minimal.

## Verification

\`\`\`
\$ dune build  # clean
\$ dune test   # 210 tests pass
\`\`\`

This is a **latent** multi-domain race. Single-domain default doesn't expose it; the existing tests don't run multi-domain signaling either. Visual review against Eio's documented \`Mutex\` semantics + Hashtbl thread-safety caveats is the verification surface here.

## Out of scope

- Migrating to \`Eio.Mutex\`-internal Hashtbl wrapper (or to an immutable Map). The current Hashtbl + Mutex pattern is consistent with the rest of the codebase.
- Read-write lock distinction. Both leave and get use \`use_ro\` for the server-side lookup; the room-side lock differs (\`use_rw\` for leave, \`use_ro\` for read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)