### PR TITLE
sec(graphql_adapter): cap JSON recursion depth in variables conversion

### DIFF
--- a/lib/graphql_adapter.ml
+++ b/lib/graphql_adapter.ml
@@ -176,24 +176,42 @@ let parse_request body : graphql_request option =
     | None -> None
   with Yojson.Json_error _ -> None
 
-(** Convert Yojson.Safe.t to Graphql_parser.const_value *)
-let rec yojson_to_const_value : Yojson.Safe.t -> Graphql_parser.const_value = function
-  | `Null -> `Null
-  | `Bool b -> `Bool b
-  | `Int i -> `Int i
-  | `Float f -> `Float f
-  | `String s -> `String s
-  | `List items -> `List (List.map yojson_to_const_value items)
-  | `Assoc fields -> `Assoc (List.map (fun (k, v) -> (k, yojson_to_const_value v)) fields)
-  | `Intlit s ->
-    (* Attempt exact int conversion; fall back to float for large integers
-       that exceed OCaml's native int range rather than silently mapping to 0. *)
-    (match int_of_string_opt s with
-     | Some i -> `Int i
-     | None ->
-       match float_of_string_opt s with
-       | Some f -> `Float f
-       | None -> `String s)
+(** Maximum recursion depth for JSON↔GraphQL conversion. GraphQL variables
+    don't legitimately nest beyond 10-20; cap at 64 leaves headroom for
+    unusual but plausible schemas while preventing a deeply-nested
+    attacker-supplied [variables] payload from blowing the call stack. *)
+let max_value_depth = 64
+
+(** Convert Yojson.Safe.t to Graphql_parser.const_value.
+    @raise Yojson.Json_error if the value nests deeper than [max_value_depth].
+           The existing [parse_request] / [batched_handler] try/with arms
+           catch this and turn it into a 400 with an "Invalid JSON" message. *)
+let yojson_to_const_value (v : Yojson.Safe.t) : Graphql_parser.const_value =
+  let rec walk depth value =
+    if depth > max_value_depth then
+      raise (Yojson.Json_error
+               (Printf.sprintf "variables nested deeper than %d levels"
+                  max_value_depth));
+    match value with
+    | `Null -> `Null
+    | `Bool b -> `Bool b
+    | `Int i -> `Int i
+    | `Float f -> `Float f
+    | `String s -> `String s
+    | `List items -> `List (List.map (walk (depth + 1)) items)
+    | `Assoc fields ->
+      `Assoc (List.map (fun (k, v) -> (k, walk (depth + 1) v)) fields)
+    | `Intlit s ->
+      (* Attempt exact int conversion; fall back to float for large integers
+         that exceed OCaml's native int range rather than silently mapping to 0. *)
+      (match int_of_string_opt s with
+       | Some i -> `Int i
+       | None ->
+         match float_of_string_opt s with
+         | Some f -> `Float f
+         | None -> `String s)
+  in
+  walk 0 v
 
 (** Convert variables to Graphql format *)
 let convert_variables (vars : Yojson.Safe.t option) : (string * Graphql_parser.const_value) list =
@@ -203,15 +221,27 @@ let convert_variables (vars : Yojson.Safe.t option) : (string * Graphql_parser.c
     List.map (fun (key, value) -> (key, yojson_to_const_value value)) pairs
   | Some _ -> []
 
-(** Convert Yojson.Basic.t to Yojson.Safe.t for response *)
-let rec basic_to_safe : Yojson.Basic.t -> Yojson.Safe.t = function
-  | `Null -> `Null
-  | `Bool b -> `Bool b
-  | `Int i -> `Int i
-  | `Float f -> `Float f
-  | `String s -> `String s
-  | `List items -> `List (List.map basic_to_safe items)
-  | `Assoc fields -> `Assoc (List.map (fun (k, v) -> (k, basic_to_safe v)) fields)
+(** Convert Yojson.Basic.t to Yojson.Safe.t for response. Same depth cap
+    as [yojson_to_const_value] — exceptionally deep server output is more
+    likely a schema bug than an attack, but the recursion would still
+    blow the stack. *)
+let basic_to_safe (v : Yojson.Basic.t) : Yojson.Safe.t =
+  let rec walk depth value =
+    if depth > max_value_depth then
+      raise (Yojson.Json_error
+               (Printf.sprintf "response nested deeper than %d levels"
+                  max_value_depth));
+    match value with
+    | `Null -> `Null
+    | `Bool b -> `Bool b
+    | `Int i -> `Int i
+    | `Float f -> `Float f
+    | `String s -> `String s
+    | `List items -> `List (List.map (walk (depth + 1)) items)
+    | `Assoc fields ->
+      `Assoc (List.map (fun (k, v) -> (k, walk (depth + 1) v)) fields)
+  in
+  walk 0 v
 
 (** Execute a GraphQL query
 


### PR DESCRIPTION
## Why

\`yojson_to_const_value\` and \`basic_to_safe\` recurse without bound on the *structure* of the input JSON. \`yojson_to_const_value\` processes **GraphQL variables — an attacker-controlled field** in the request body.

\`\`\`
POST /graphql
{
  \"query\": \"...\",
  \"variables\": {\"a\":{\"a\":{\"a\":...10 000 levels...}}}
}
\`\`\`

Yojson's parser has its own structural limits, but a payload below those limits can still overflow our naive converter — \`List.map\` doesn't run in constant stack, and \`Assoc\` recursion accumulates one frame per nesting level.

Stack overflow crashes the request fiber. With PR #91's server-level catch in place the client gets a 500 instead of a connection reset, but a single ~32 KB request payload can take down arbitrary fibers — cheap DoS.

\`basic_to_safe\` converts schema-side response output. Less likely to hit attacker control directly, but a buggy schema producing deeply-nested output would crash the response path the same way — same fix applied for consistency.

## Change

\`\`\`ocaml
let max_value_depth = 64

let yojson_to_const_value (v : Yojson.Safe.t) : Graphql_parser.const_value =
  let rec walk depth value =
    if depth > max_value_depth then
      raise (Yojson.Json_error \"variables nested deeper than 64 levels\");
    match value with
    | ...
    | \`List items -> \`List (List.map (walk (depth + 1)) items)
    | \`Assoc fields -> \`Assoc (List.map (fun (k, v) -> (k, walk (depth + 1) v)) fields)
    | ...
  in walk 0 v
\`\`\`

\`Yojson.Json_error\` is the existing error type the upstream \`try/with\` arms in \`parse_request\` and \`batched_handler\` already catch — they turn it into a 400 with \"Invalid JSON\". No new exception type to wire through.

### Why 64

GraphQL variables don't legitimately nest beyond 10-20 in practice (typical query: 3-5 levels). 64 leaves headroom for unusual but plausible schemas while bounding the call stack to ~1 KB worth of frames. Same constant for \`basic_to_safe\`.

### Pattern guard caveat

\`| _ when depth > N -> raise\` doesn't satisfy OCaml's exhaustive-match check (warning 8). Hoisted the depth check to a pre-match \`if ... then raise\` to keep the type-checker happy without disabling the warning.

## Verification

\`\`\`
\$ dune build  # clean
\$ dune test   # 210 tests, all green
\`\`\`

No new test exercises the depth limit. A test that constructs a 65-deep JSON would either need a Yojson helper or string-template approach — out of scope for this PR; tracked as future work.

## Out of scope

- Tail-recursive \`List.map\` for the *list-length* dimension. A \`variables\` payload with a million-element list still grows the stack via \`List.map\`. This PR only addresses the *nesting* dimension; list-length is a separate concern (Yojson's parser limit usually catches it first).
- Same audit pass for other JSON consumers (\`mcp_adapter\`, \`webrtc_signaling\`, etc.) — those use \`Yojson.Safe.Util.member\`/\`to_string\` which is constant-stack per access; not the same risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)