### PR TITLE
sec(auth/csrf): uniform rejection message, log specifics server-side

### DIFF
--- a/lib/auth/csrf.ml
+++ b/lib/auth/csrf.ml
@@ -160,7 +160,16 @@ let middleware ~secret ?(field_name = default_field_name)
           match validate ~secret ~session_id ~field_name ~header_name req with
           | Ok () -> handler req
           | Error msg ->
-              Kirin.Response.text ~status:`Forbidden ("CSRF validation failed: " ^ msg)
+              (* Log the specific reason server-side; never echo it to the
+                 client. The pre-fix code returned messages like
+                 "Invalid signature" vs "Session mismatch" vs "Token
+                 expired", which let an attacker probe *which* check
+                 failed and tune their attack — focus on signing-key
+                 guessing if the signature was the rejection, focus on
+                 session hijack if the signature passed, etc. Uniform
+                 rejection denies that oracle. *)
+              Kirin.Logger.warn "CSRF validation failed: %s" msg;
+              Kirin.Response.text ~status:`Forbidden "CSRF validation failed"
 
 (** {1 Template Helpers} *)
 


### PR DESCRIPTION
## Why

The CSRF middleware echoed \`validate\`'s specific error string into the response:

\`\`\`ocaml
| Error msg ->
    Kirin.Response.text ~status:\`Forbidden
      (\"CSRF validation failed: \" ^ msg)
\`\`\`

\`msg\` is one of:

| Message | Implication for an attacker |
|---|---|
| \"Invalid token encoding\" | base64 decode failed — token format wrong |
| \"Invalid token format\" | structure wrong (no dot separator) |
| \"Invalid signature\" | structure OK, *signature* wrong — focus on signing-key guess |
| \"Session mismatch\" | signature OK, *session-id* mismatch — focus on session hijack |
| \"Token expired\" | token was *once valid* — maybe replay attack |
| \"Invalid expiration\" / \"Invalid token data\" | malformed payload |

This is a **which-check-failed oracle**. An attacker can iterate through CSRF token shapes and learn *exactly* what to focus on. Each error narrows the search.

Standard CSRF hardening: return a single uniform \"rejected\" — never tell the attacker which check tripped.

## Change

\`\`\`ocaml
| Error msg ->
    Kirin.Logger.warn \"CSRF validation failed: %s\" msg;
    Kirin.Response.text ~status:\`Forbidden \"CSRF validation failed\"
\`\`\`

Operators still see the specific reason in server logs. The client sees only the category (403 + fixed string).

## Verification

\`\`\`
\$ dune build  # clean
\$ dune test   # all green
\`\`\`

## Pattern continuity

Same info-disclosure family as the audit pass that produced #91 (server-level), #92 (jwt), #94 (mcp_adapter), #95 (qwik/astro), #96 (tanstack), #97 (password CSPRNG), #98 (webrtc peer_id), and #232 (wkbl admin timing oracle).

## Out of scope

- Audit other authentication middleware for similar oracles. \`auth_middleware.ml\` returns 401 with no error detail; \`jwt.ml\` decode returns specific errors but it's a library function (caller responsibility). Spot-checked, no immediate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)