### PR TITLE
sec(auth_middleware): uniform JWT rejection, log specifics server-side

### DIFF
--- a/lib/auth/auth_middleware.ml
+++ b/lib/auth/auth_middleware.ml
@@ -71,10 +71,25 @@ let extract_bearer_token req =
       else
         None
 
+(** Default on_error for JWT auth. Logs the specific reason (token
+    expired / invalid signature / unsupported algorithm / ...)
+    server-side, returns a uniform [{"error":"Unauthorized"}]. Echoing
+    the specific reason to the client lets an attacker probe *which*
+    check tripped — "Token expired" reveals the token was once valid
+    (replayable if a copy can be obtained), "Invalid signature" tells
+    them to focus on signing-key recovery, etc. Standard hardening
+    keeps the response uniform.
+
+    Applications that explicitly want detail in the response (internal
+    debug builds, server-to-server APIs with trusted callers) can pass
+    a custom [~on_error] that surfaces [msg]. *)
+let default_jwt_on_error _req msg =
+  Kirin.Logger.warn "JWT auth failed: %s" msg;
+  Kirin.Response.json ~status:`Unauthorized
+    (`Assoc [("error", `String "Unauthorized")])
+
 (** JWT authentication middleware *)
-let jwt ~secret ?(on_error = fun _req msg ->
-    Kirin.Response.json ~status:`Unauthorized
-      (`Assoc [("error", `String msg)])) handler =
+let jwt ~secret ?(on_error = default_jwt_on_error) handler =
   fun req ->
     match extract_bearer_token req with
     | None -> on_error req "Missing or invalid Authorization header"
@@ -89,8 +104,7 @@ let jwt ~secret ?(on_error = fun _req msg ->
 
 (** JWT middleware with custom claim extraction *)
 let jwt_with_claims ~secret ~extract_user_id ?on_error handler =
-  let on_error = Option.value on_error ~default:(fun _req msg ->
-    Kirin.Response.json ~status:`Unauthorized (`Assoc [("error", `String msg)])) in
+  let on_error = Option.value on_error ~default:default_jwt_on_error in
   fun req ->
     match extract_bearer_token req with
     | None -> on_error req "Missing Authorization header"


### PR DESCRIPTION
## Why

The JWT middleware default \`on_error\` echoed \`Jwt.decode\`'s specific error string into the response body:

\`\`\`ocaml
| Error msg -> on_error req msg
...with on_error = fun _req msg ->
  Response.json ~status:\`Unauthorized
    (\`Assoc [(\"error\", \`String msg)])
\`\`\`

\`Jwt.decode\` returns one of (cf. PR #92): \"Invalid token format\", \"Invalid header encoding\", \"Invalid header JSON\", \"Missing alg in header\", \"Unsupported algorithm: <alg>\", \"Invalid signature\", \"Invalid payload encoding\", \"Invalid payload JSON\", \"Token expired\", \"Token not yet valid\".

This is the same **which-check-failed oracle** PR #103 closed for CSRF. Concretely:

| Echoed message | What it tells an attacker |
|---|---|
| \"Token expired\" | The token was *once valid* — replay-able if they can obtain a copy from logs/leaked storage. |
| \"Invalid signature\" | Format/encoding/algorithm passed — focus on signing-key recovery. |
| \"Unsupported algorithm: HS256\" | Reveals which alg the server accepts — useful for algorithm-confusion attacks. |
| \"Token not yet valid\" | Reveals an \`nbf\` claim is in effect — clock-skew probing. |

## Change

Factor out \`default_jwt_on_error\` that:

1. Logs the specific reason via \`Kirin.Logger.warn\`.
2. Returns a uniform \`{\"error\":\"Unauthorized\"}\`.

Both \`jwt\` and \`jwt_with_claims\` use the same default. Applications that explicitly want detail in the response (debug builds, trusted server-to-server APIs) can still pass a custom \`~on_error\` that surfaces the message.

## Verification

\`\`\`
\$ dune build  # clean
\$ dune exec test/test_auth.exe   # 30 tests, all green
\`\`\`

## Pattern continuity

Same family as PR #91, #92, #94, #95, #96, #103 (auth oracles + info leaks). Sibling to PR #103 (CSRF uniform reject) — exact same shape one layer up.

## Out of scope

- Same audit for \`session\` and \`api_key\` middleware. \`session\`'s default \`on_error\` redirects to \`/login\` (no message leak). \`api_key\`'s default returns \`\"Invalid API key\"\` without distinguishing missing vs wrong vs format — already uniform. No fix needed there.
- A \`debug_jwt_on_error\` helper that explicitly *enables* detailed messages for dev. Defer until a caller wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)