### PR TITLE
fix(i18n): reject fallback cycles at set_fallback (defense-in-depth follow-up to #100)

### DIFF
--- a/lib/i18n.ml
+++ b/lib/i18n.ml
@@ -140,8 +140,48 @@ let add_plural locale ~key ~one ~other ?zero ?few ?many t =
   Hashtbl.replace t.locales locale locale_data;
   t
 
-(** Set fallback locale *)
+(** Maximum walk depth for the cycle check. Matches the lookup-time
+    cap used in [get_translation] (currently inlined as a literal there;
+    a follow-up RFC could unify both as a module-level constant). 16 is
+    well above any practical chain length. *)
+let cycle_check_max_depth = 16
+
+(** Check whether following [fallback] in [t] would land back on
+    [origin] — i.e. installing [origin → fallback] would close a cycle.
+
+    Walks the existing fallback chain from [fallback]. A separate
+    runtime depth cap already prevents stack overflow on a cycle, but
+    *creating* a cycle silently makes every key in the cycle "missing"
+    (lookup terminates at the cap with None). Reject at the setter so
+    the configuration mistake surfaces immediately. *)
+let creates_cycle t ~origin ~fallback =
+  let rec walk depth loc =
+    if depth > cycle_check_max_depth then false
+    else if loc = origin then true
+    else match Hashtbl.find_opt t.locales loc with
+      | None -> false
+      | Some ld ->
+        match ld.fallback with
+        | None -> false
+        | Some next -> walk (depth + 1) next
+  in
+  walk 0 fallback
+
+(** Set fallback locale.
+
+    Raises [Invalid_argument] when installing this fallback would create
+    a cycle (e.g. setting en's fallback to ko on a config that already
+    has ko's fallback set to en). Catching the cycle at install time
+    means a misconfigured chain surfaces immediately instead of making
+    every lookup quietly return the default once the depth cap trips. *)
 let set_fallback ~locale ~fallback t =
+  if locale = fallback then
+    invalid_arg
+      (Printf.sprintf "I18n.set_fallback: locale %S cannot fall back to itself" locale);
+  if creates_cycle t ~origin:locale ~fallback then
+    invalid_arg
+      (Printf.sprintf "I18n.set_fallback: %S -> %S would create a fallback cycle"
+         locale fallback);
   match Hashtbl.find_opt t.locales locale with
   | Some ld ->
     Hashtbl.replace t.locales locale { ld with fallback = Some fallback };

--- a/test/test_i18n.ml
+++ b/test/test_i18n.ml
@@ -273,6 +273,24 @@ let locale_management_tests = [
     let msg = I18n.translate i18n ~locale:"en-US" "greeting" in
     Alcotest.(check string) "fallback used" "Hello" msg
   );
+
+  "set fallback rejects self-loop", `Quick, (fun () ->
+    let i18n = I18n.create () |> I18n.add_translations "en" [] in
+    Alcotest.check_raises "self loop"
+      (Invalid_argument "I18n.set_fallback: locale \"en\" cannot fall back to itself")
+      (fun () -> ignore (I18n.set_fallback ~locale:"en" ~fallback:"en" i18n))
+  );
+
+  "set fallback rejects multi-step cycle", `Quick, (fun () ->
+    let i18n = I18n.create ()
+      |> I18n.add_translations "en" []
+      |> I18n.add_translations "ko" []
+      |> I18n.set_fallback ~locale:"ko" ~fallback:"en" in
+    Alcotest.check_raises "ko -> en already; en -> ko would cycle"
+      (Invalid_argument
+         "I18n.set_fallback: \"en\" -> \"ko\" would create a fallback cycle")
+      (fun () -> ignore (I18n.set_fallback ~locale:"en" ~fallback:"ko" i18n))
+  );
 ]
 
 let formatting_tests = [


### PR DESCRIPTION
## Why

PR #100 added a lookup-time depth cap (16) so a cyclic fallback config can't lock a request. That contains the runtime damage but **leaves the misconfiguration latent**: every key in the cycle silently returns the default once the cap trips, with no signal pointing back to the offending \`set_fallback\` call.

## What

- \`Kirin.I18n.set_fallback\` now raises \`Invalid_argument\` if installing the fallback would create a cycle.
  - Self-loop: \`set_fallback ~locale:\"en\" ~fallback:\"en\"\`.
  - Multi-step: \`set_fallback ~locale:\"en\" ~fallback:\"ko\"\` when \`ko -> en\` already exists.
- Cycle walk reuses depth cap 16 as defense-in-depth in case the existing chain is somehow already cyclic before this guard ships.
- Error messages name both locales so the operator can locate the offending call site immediately.

## Relationship to #100

- #100 is the **runtime cap** — keeps lookups bounded.
- This is the **install-time guard** — keeps the config itself coherent.

They're complementary; either alone leaves a hole (config-time-only would miss programmatic chains assembled across modules; runtime-only loses the failure signal).

The constant is defined locally (\`cycle_check_max_depth = 16\`) rather than reusing #100's \`max_fallback_depth\` because this branch is based on \`main\`. If both land, the constants fold in a follow-up cleanup.

## Tests

\`test/test_i18n.exe\`: 40 pass.
- 38 existing
- 1 new: \`set fallback rejects self-loop\` (\`Alcotest.check_raises\`)
- 1 new: \`set fallback rejects multi-step cycle\` (\`Alcotest.check_raises\`)

Negative tests guarantee the guard branches aren't dead code that a future refactor could quietly strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)