### PR TITLE
fix(static): reject symlink escapes from the served directory

### DIFF
--- a/lib/static.ml
+++ b/lib/static.ml
@@ -29,40 +29,67 @@ let contains_dot_dot path =
 
 let is_safe_path path = not (contains_dot_dot path)
 
+(** Resolve [relative_path] under [dir] and require the result to live
+    inside [dir] after symlink canonicalization.
+
+    [contains_dot_dot] only blocks literal [..] segments in the request
+    path. It does not see filesystem-level symlinks: a benign-looking
+    file [dir/innocent.txt] that is itself a symlink to [/etc/passwd]
+    bypasses every textual check and is happily read by [load_binary],
+    which opens with default symlink-follow semantics. realpath collapses
+    the entire symlink chain to a single absolute path, so requiring the
+    canonical candidate to sit under the canonical [dir] catches both
+    the symlink case and any residual textual escape the parser missed.
+
+    Returns [None] on missing files (so callers fall through to the next
+    handler rather than leaking existence) or escape attempts. *)
+let resolve_under ~dir relative_path =
+  let candidate = Filename.concat dir relative_path in
+  try
+    let real_candidate = Unix.realpath candidate in
+    let real_dir = Unix.realpath dir in
+    let sep = Filename.dir_sep in
+    let prefix = real_dir ^ sep in
+    if real_candidate = real_dir then Some real_candidate
+    else if String.length real_candidate > String.length prefix
+            && String.sub real_candidate 0 (String.length prefix) = prefix
+    then Some real_candidate
+    else None
+  with Unix.Unix_error _ -> None
+
 (** Static file middleware *)
 let static prefix ~dir =
   fun next req ->
     let path = Request.path req in
     if String.length path >= String.length prefix &&
        String.sub path 0 (String.length prefix) = prefix then
-      let relative_path = 
+      let relative_path =
         String.sub path (String.length prefix) (String.length path - String.length prefix)
       in
-      
+
       (* Remove leading slash to prevent Filename.concat treating it as absolute *)
-      let relative_path = 
+      let relative_path =
         if String.length relative_path > 0 && relative_path.[0] = '/' then
           String.sub relative_path 1 (String.length relative_path - 1)
         else
           relative_path
       in
-      
+
       if contains_dot_dot relative_path then
         Response.make ~status:`Forbidden (`String "Forbidden")
         |> Response.with_header "content-type" "text/plain"
       else
-        let file_path = Filename.concat dir relative_path in
-        if Fs_compat.file_exists file_path && not (Fs_compat.is_directory file_path) then
-          let content = Fs_compat.load_binary file_path in
-          let len = String.length content in
-
-          let ext = Filename.extension file_path in
-          let mime = mime_of_ext ext in
-          
-          Response.make ~status:`OK (`String content)
-          |> Response.with_header "content-type" mime
-          |> Response.with_header "content-length" (string_of_int len)
-        else
-          next req
+        match resolve_under ~dir relative_path with
+        | None -> next req
+        | Some file_path ->
+          if Fs_compat.is_directory file_path then next req
+          else
+            let content = Fs_compat.load_binary file_path in
+            let len = String.length content in
+            let ext = Filename.extension file_path in
+            let mime = mime_of_ext ext in
+            Response.make ~status:`OK (`String content)
+            |> Response.with_header "content-type" mime
+            |> Response.with_header "content-length" (string_of_int len)
     else
       next req

--- a/lib/static.mli
+++ b/lib/static.mli
@@ -22,6 +22,17 @@ val get_mime_type : string -> string
     Used to prevent directory traversal attacks. *)
 val is_safe_path : string -> bool
 
+(** [resolve_under ~dir relative_path] returns the canonical absolute path
+    of [Filename.concat dir relative_path] only when that canonical path
+    lies inside [Unix.realpath dir]. Returns [None] for missing files,
+    broken symlinks, or paths whose canonical form escapes [dir].
+
+    This catches symlink-based traversal that [is_safe_path]/[contains_dot_dot]
+    cannot see: a file under [dir] that is itself a symlink pointing outside
+    [dir] is rejected here even though its request path contains no [..]
+    segments. Exposed for direct testing of the escape guard. *)
+val resolve_under : dir:string -> string -> string option
+
 (** {1 Middleware} *)
 
 (** [static prefix ~dir next req] serves static files from [dir] for requests
@@ -29,6 +40,9 @@ val is_safe_path : string -> bool
     does not match or the file does not exist.
 
     Returns 403 Forbidden if the path contains directory traversal attempts.
+    Symlinks within [dir] that resolve outside [dir] are treated as
+    not-found (fall through to [next]) rather than 403, so the response
+    does not confirm the existence of the symlink target.
 
     {b Example:}
     {[

--- a/test/test_router_suite.ml
+++ b/test/test_router_suite.ml
@@ -113,7 +113,69 @@ let test_static_safe_path () =
   check bool "traversal" false (Kirin.Static.is_safe_path "../etc/passwd");
   check bool "hidden traversal" false (Kirin.Static.is_safe_path "foo/../../bar")
 
+(* Symlink-escape regression tests. The textual [..] check cannot see
+   filesystem-level symlinks, so [resolve_under] is the guard that
+   actually keeps responses inside [dir]. These tests must not be
+   deleted in a "tidy up" pass: they pin the guard against decay. *)
+let with_temp_dir f =
+  let stem = Filename.temp_file "kirin_static_" "" in
+  Unix.unlink stem;
+  Unix.mkdir stem 0o755;
+  let cleanup () =
+    let rec rm p =
+      match (Unix.lstat p).st_kind with
+      | S_DIR ->
+        Array.iter (fun child -> rm (Filename.concat p child)) (Sys.readdir p);
+        Unix.rmdir p
+      | _ -> Unix.unlink p
+    in
+    try rm stem with _ -> ()
+  in
+  Fun.protect ~finally:cleanup (fun () -> f stem)
+
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let test_static_resolve_regular_file () =
+  with_temp_dir (fun dir ->
+    let path = Filename.concat dir "hello.txt" in
+    write_file path "hi";
+    match Kirin.Static.resolve_under ~dir "hello.txt" with
+    | Some _ -> ()
+    | None -> Alcotest.fail "expected regular file to resolve")
+
+let test_static_resolve_missing_file () =
+  with_temp_dir (fun dir ->
+    check (option string) "missing file falls through (not 403)"
+      None (Kirin.Static.resolve_under ~dir "does-not-exist.txt"))
+
+let test_static_resolve_symlink_within_dir () =
+  with_temp_dir (fun dir ->
+    let real = Filename.concat dir "real.txt" in
+    let link = Filename.concat dir "alias.txt" in
+    write_file real "ok";
+    Unix.symlink "real.txt" link;
+    match Kirin.Static.resolve_under ~dir "alias.txt" with
+    | Some _ -> ()
+    | None -> Alcotest.fail "symlink that stays inside dir must resolve")
+
+let test_static_resolve_symlink_escape () =
+  with_temp_dir (fun dir ->
+    with_temp_dir (fun outside ->
+      let secret = Filename.concat outside "secret.txt" in
+      write_file secret "PASSWORD";
+      let link = Filename.concat dir "innocent.txt" in
+      Unix.symlink secret link;
+      check (option string) "symlink that escapes dir is rejected"
+        None (Kirin.Static.resolve_under ~dir "innocent.txt")))
+
 let static_tests = [
   test_case "mime type detection" `Quick test_static_mime_type;
   test_case "path safety check" `Quick test_static_safe_path;
+  test_case "resolve regular file" `Quick test_static_resolve_regular_file;
+  test_case "resolve missing falls through" `Quick test_static_resolve_missing_file;
+  test_case "resolve symlink within dir" `Quick test_static_resolve_symlink_within_dir;
+  test_case "resolve symlink escape rejected" `Quick test_static_resolve_symlink_escape;
 ]


### PR DESCRIPTION
## Why

\`lib/static.ml\` advertises \"directory traversal protection\" but the only guard is \`contains_dot_dot\` — a textual check on literal \`..\` segments. That guard is blind to filesystem-level symlinks:

\`\`\`
Request:    GET /static/innocent.txt
Filesystem: dir/innocent.txt -> /etc/passwd
\`\`\`

No \`..\` in the request, so the textual check passes. \`Fs_compat.file_exists\` and \`Fs_compat.is_directory\` both call \`Eio.Path.kind ~follow:true\` (or \`Sys.file_exists\`/\`Sys.is_directory\` in the fallback), and \`Fs_compat.load_binary\` opens with default symlink-following semantics. The response is \`/etc/passwd\`.

This breaks the *advertised* boundary guarantee of the middleware, so the fix is scoped as closing a hole — not adding a feature.

## What

- New helper \`resolve_under ~dir relative_path\` canonicalizes both \`dir\` and the candidate with \`Unix.realpath\` and requires the canonical candidate to be either exactly \`real_dir\` or strictly under \`real_dir + Filename.dir_sep\`. realpath collapses every symlink in the chain, so a candidate pointing outside \`dir\` is detected even when no \`..\` appears textually.
- Middleware now calls \`resolve_under\`. Escape attempts fall through to \`next req\` (404 by convention) rather than 403, so the response does not confirm existence of the symlink target.
- The literal-\`..\` 403 path is preserved — those requests still get a clear rejection because they are an unambiguous attack signal.
- Symlinks within \`dir\` (e.g., versioned asset bundles emitting symlinks) continue to work; only the canonical form is required to stay under \`dir\`.

## Testing

\`test/test_router_suite.ml\` adds 4 regression tests using real \`Unix.symlink\` calls in temp dirs:

1. \`resolve regular file\` — non-symlink baseline.
2. \`resolve missing falls through\` — missing path returns \`None\` (no 403 leak for nonexistent files).
3. \`resolve symlink within dir\` — symlink whose target is also under \`dir\` still resolves (guard is not over-restrictive).
4. \`resolve symlink escape rejected\` — symlink whose target is in a separate temp dir resolves to \`None\` (the actual escape case).

Full suite: 99/99 pass.

## Out of scope

- Dotfile blocking (\`.git/HEAD\`, \`.env\`) — that's a feature decision (opt-in vs default-deny semantics) and a separate PR.
- Hot-path caching of \`Unix.realpath dir\` — premature; \`static\` already does multiple syscalls per request, and the new one short-circuits escape traffic before the read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)