### PR TITLE
fix(cookie): reject CR/LF/NUL in Set-Cookie name and attribute values

### DIFF
--- a/lib/cookie.ml
+++ b/lib/cookie.ml
@@ -50,8 +50,45 @@ let get_all req =
   | Some header_value -> parse_cookies header_value
   | None -> []
 
+(* Reject CR / LF / NUL anywhere in a string that will be interpolated
+   raw into a Set-Cookie header. These three bytes are the wire-level
+   header terminators / separators; a caller that lands one of them in
+   [name], [path], [domain], or [expires] would otherwise emit a
+   response like
+
+     Set-Cookie: name=value
+     Set-Cookie: evil=1; Path=...
+
+   — i.e. CRLF injection of a second arbitrary cookie. Other ASCII
+   control bytes are not as universally a separator (tab is legal OWS,
+   for example), so we limit the reject set to the three bytes that
+   are *always* unsafe in an HTTP header value.
+
+   Raising [Invalid_argument] is the right shape: the caller is the
+   server code constructing the cookie, not an end-user input parser,
+   so silently sanitizing would hide a programming bug rather than
+   surface it. The cookie [value] is left to [Uri.pct_encode] (CR / LF
+   / NUL all encode to percent-escape, so they cannot escape on the
+   wire), but [name] is *not* pct-encoded, so we must validate it
+   explicitly — a caller building dynamic cookie names from user input
+   (e.g. ["pref-" ^ user_id]) would be unsafe without this gate. *)
+let reject_header_injection ~field s =
+  String.iter (fun c ->
+    let code = Char.code c in
+    if code = 0x0A || code = 0x0D || code = 0x00 then
+      invalid_arg
+        (Printf.sprintf
+           "Cookie.%s contains illegal control character (0x%02X); \
+            refusing to emit Set-Cookie header"
+           field code)
+  ) s
+
 (** Build Set-Cookie header value *)
 let build_set_cookie name value attrs =
+  reject_header_injection ~field:"name" name;
+  Option.iter (reject_header_injection ~field:"expires") attrs.expires;
+  Option.iter (reject_header_injection ~field:"domain") attrs.domain;
+  Option.iter (reject_header_injection ~field:"path") attrs.path;
   let buf = Buffer.create 128 in
   (* Name=Value *)
   Buffer.add_string buf name;

--- a/test/test_cookie_suite.ml
+++ b/test/test_cookie_suite.ml
@@ -56,6 +56,59 @@ let test_cookie_signed () =
   let tampered_result = Kirin.Cookie.verify tampered in
   check (option string) "tampered should fail" None tampered_result
 
+(* Set-Cookie header-injection regression tests. The validator in
+   build_set_cookie rejects CR, LF, and NUL anywhere in [name], [path],
+   [domain], or [expires]; this group pins each rejection so a future
+   refactor cannot quietly turn one of the fields back into a raw
+   sprintf interpolation. [value] is left to Uri.pct_encode (it
+   handles control bytes), so the round-trip there is verified by the
+   existing tests above. *)
+
+let expect_invalid_arg ~label f =
+  check_raises label
+    (Invalid_argument
+       "")  (* message text is descriptive; we only assert the exception kind *)
+    (fun () ->
+       try f () with Invalid_argument _ -> raise (Invalid_argument ""))
+
+let test_cookie_build_rejects_crlf_in_name () =
+  expect_invalid_arg ~label:"CR in name" (fun () ->
+    ignore (Kirin.Cookie.build_set_cookie "a\rb" "v" Kirin.Cookie.default_attributes));
+  expect_invalid_arg ~label:"LF in name" (fun () ->
+    ignore (Kirin.Cookie.build_set_cookie "a\nb" "v" Kirin.Cookie.default_attributes));
+  expect_invalid_arg ~label:"NUL in name" (fun () ->
+    ignore (Kirin.Cookie.build_set_cookie "a\x00b" "v" Kirin.Cookie.default_attributes))
+
+let test_cookie_build_rejects_crlf_in_path () =
+  let attrs = { Kirin.Cookie.default_attributes
+                with path = Some "/foo\r\nSet-Cookie: evil=1" } in
+  expect_invalid_arg ~label:"CRLF in path" (fun () ->
+    ignore (Kirin.Cookie.build_set_cookie "session" "v" attrs))
+
+let test_cookie_build_rejects_crlf_in_domain () =
+  let attrs = { Kirin.Cookie.default_attributes
+                with domain = Some "ok.com\r\nX-Evil: 1" } in
+  expect_invalid_arg ~label:"CRLF in domain" (fun () ->
+    ignore (Kirin.Cookie.build_set_cookie "session" "v" attrs))
+
+let test_cookie_build_rejects_crlf_in_expires () =
+  let attrs = { Kirin.Cookie.default_attributes
+                with expires = Some "Thu, 01 Jan 1970 00:00:00 GMT\r\nSet-Cookie: e=1" } in
+  expect_invalid_arg ~label:"CRLF in expires" (fun () ->
+    ignore (Kirin.Cookie.build_set_cookie "session" "v" attrs))
+
+let test_cookie_build_value_with_crlf_is_encoded () =
+  (* Defense-in-depth check: pct_encode handles CR/LF in value, so the
+     wire bytes never carry literal control characters even if a
+     caller passes them. This pins that the existing pct_encode path
+     stays in effect (i.e. nobody "optimizes" it out alongside the
+     new validator). *)
+  let header =
+    Kirin.Cookie.build_set_cookie "session" "a\r\nb" Kirin.Cookie.default_attributes
+  in
+  check bool "no literal CR in wire bytes" false (string_contains header "\r");
+  check bool "no literal LF in wire bytes" false (string_contains header "\n")
+
 let tests = [
   test_case "parse cookies" `Quick test_cookie_parse;
   test_case "parse empty cookies" `Quick test_cookie_parse_empty;
@@ -63,4 +116,9 @@ let tests = [
   test_case "set cookie on response" `Quick test_cookie_set_on_response;
   test_case "delete cookie" `Quick test_cookie_delete;
   test_case "signed cookies" `Quick test_cookie_signed;
+  test_case "build rejects CRLF/NUL in name" `Quick test_cookie_build_rejects_crlf_in_name;
+  test_case "build rejects CRLF in path" `Quick test_cookie_build_rejects_crlf_in_path;
+  test_case "build rejects CRLF in domain" `Quick test_cookie_build_rejects_crlf_in_domain;
+  test_case "build rejects CRLF in expires" `Quick test_cookie_build_rejects_crlf_in_expires;
+  test_case "value with CRLF is pct-encoded" `Quick test_cookie_build_value_with_crlf_is_encoded;
 ]


### PR DESCRIPTION
## Why

\`build_set_cookie\` interpolates \`name\`, \`path\`, \`domain\`, and \`expires\` straight into the Set-Cookie header value via \`sprintf\`. CR / LF / NUL are wire-level HTTP header separators, so a caller that lands one of those bytes in any of these fields emits:

\`\`\`
Set-Cookie: name=value
Set-Cookie: evil=1; Path=/
\`\`\`

— **Set-Cookie injection** of a second arbitrary cookie. The pattern that turns this into a practical exploit is dynamic cookie-name construction from user input (\`\"pref-\" ^ user_id\`), which does appear in app code.

\`Uri.pct_encode\` is already applied to \`value\`, so CR/LF/NUL in value encode to percent-escape and cannot escape on the wire. But:
- \`name\` is **not** pct-encoded.
- The three attribute string fields are pure sprintf concat.

That asymmetry is the hole.

## What

New \`reject_header_injection\` helper walks the input and raises \`Invalid_argument\` on any byte in \`{0x0A, 0x0D, 0x00}\`. \`build_set_cookie\` runs it on \`name\` and on every \`Option.iter\` of the three attribute fields before the buffer build.

The reject set is intentionally narrow:
- Other ASCII control bytes (tab, VT, FF, ...) are not as universally header-fatal — tab is legal OWS, for example. A wider reject set is a separate posture decision, not a fix to this hole.

\`Invalid_argument\` is the right shape: callers of \`build_set_cookie\` are server code constructing a response, not end-user input parsers. Silently sanitizing would hide a programming bug; loud failure surfaces it at test time.

## Tests

5 new in \`test_cookie_suite.ml\`:

| Test | Pins |
|---|---|
| build rejects CR/LF/NUL in name | the new \`name\` validator (three sub-cases) |
| build rejects CRLF in path | \`path\` attribute validator |
| build rejects CRLF in domain | \`domain\` attribute validator |
| build rejects CRLF in expires | \`expires\` attribute validator |
| value with CRLF is pct-encoded | defense-in-depth: \`Uri.pct_encode\` on value must not be dropped alongside the name/attribute validator. The existing wire-encoding behaviour stays the second line of defense. |

The last test is the defense-in-depth pin: a careless \"simplification\" that removed \`Uri.pct_encode\` and replaced it with the new validator on value would make value injection re-emerge if the validator's reject set was later narrowed. Pin both paths.

Full suite: all existing tests pass; new tests pin each rejection individually so a refactor trips a specific case.

## Out of scope

- Token-char validation per RFC 6265 for cookie name (rejects [\`!#$%&'*+-.^_\`|~\` ... ]) — wider posture, separate PR.
- Validation of \`value\` against the same control-byte set — currently handled by pct_encode; could be added as belt-and-suspenders if a refactor risk profile justified it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)