### PR TITLE
fix(template): cap partial-include depth to prevent cyclic stack overflow

### DIFF
--- a/lib/template.ml
+++ b/lib/template.ml
@@ -232,15 +232,37 @@ type partials = string -> string option
 (** No partials *)
 let no_partials _ = None
 
-(** Render AST to string *)
-let rec render_nodes ?(partials = no_partials) ctx nodes =
+(** Maximum partial-include nesting depth.
+
+    Partials are resolved by a caller-supplied [partials] function, so
+    a cyclic resolver — [fun "a" -> Some "{{> b}}" | "b" -> Some
+    "{{> a}}"] — recurses unboundedly through [render -> Partial ->
+    render -> Partial -> ...] and blows the OCaml call stack, taking
+    the process down even though the template author and the resolver
+    author each thought their piece was fine in isolation.
+
+    The cap is on *partial* nesting only; ordinary section nesting
+    (if / unless / each) is bounded by the static template's own size
+    and is not influenced by the resolver, so charging those would
+    slow normal renders without buying any safety. 32 levels is well
+    past anything a hand-authored layout needs (typical stacks: page
+    -> layout -> sidebar -> snippet, ~4 deep) but stops cycles cold.
+    Hitting the cap logs a warning and emits the empty string for the
+    offending expansion site — the surrounding template still
+    renders, so the caller sees a visible gap rather than a 500. *)
+let max_partial_depth = 32
+
+(* The render trio is mutually recursive and threads a [depth] counter
+   that increments only when crossing a partial boundary. The
+   public-facing entries below start at depth 0. *)
+let rec render_nodes_d ~partials ~depth ctx nodes =
   let buf = Buffer.create 256 in
   List.iter (fun node ->
-    Buffer.add_string buf (render_node ~partials ctx node)
+    Buffer.add_string buf (render_node_d ~partials ~depth ctx node)
   ) nodes;
   Buffer.contents buf
 
-and render_node ?(partials = no_partials) ctx = function
+and render_node_d ~partials ~depth ctx = function
   | Text s -> s
   | Comment -> ""
   | Var (key, escape) ->
@@ -252,15 +274,15 @@ and render_node ?(partials = no_partials) ctx = function
   | If (key, then_nodes, else_nodes) ->
     let value = lookup ctx key in
     if Option.map is_truthy value = Some true then
-      render_nodes ~partials ctx then_nodes
+      render_nodes_d ~partials ~depth ctx then_nodes
     else
       (match else_nodes with
-       | Some nodes -> render_nodes ~partials ctx nodes
+       | Some nodes -> render_nodes_d ~partials ~depth ctx nodes
        | None -> "")
   | Unless (key, nodes) ->
     let value = lookup ctx key in
     if Option.map is_truthy value <> Some true then
-      render_nodes ~partials ctx nodes
+      render_nodes_d ~partials ~depth ctx nodes
     else
       ""
   | Each (key, nodes) ->
@@ -280,19 +302,35 @@ and render_node ?(partials = no_partials) ctx = function
                      ("@first", `Bool (i = 0));
                      ("@last", `Bool (i = List.length items - 1))]
          in
-         render_nodes ~partials item_ctx nodes
+         render_nodes_d ~partials ~depth item_ctx nodes
        ) items in
        String.concat "" results
      | _ -> "")
   | Partial name ->
-    (match partials name with
-     | Some partial_template -> render ~partials ctx partial_template
-     | None -> "")
+    if depth >= max_partial_depth then begin
+      Printf.eprintf
+        "[template] partial expansion depth %d exceeded — cyclic include? \
+         aborting at %S\n%!"
+        max_partial_depth name;
+      ""
+    end else
+      (match partials name with
+       | Some partial_template ->
+         let inner = parse partial_template in
+         render_nodes_d ~partials ~depth:(depth + 1) ctx inner
+       | None -> "")
+
+(** Render AST to string *)
+let render_nodes ?(partials = no_partials) ctx nodes =
+  render_nodes_d ~partials ~depth:0 ctx nodes
+
+let render_node ?(partials = no_partials) ctx node =
+  render_node_d ~partials ~depth:0 ctx node
 
 (** Main render function *)
-and render ?(partials = no_partials) ctx template =
+let render ?(partials = no_partials) ctx template =
   let nodes = parse template in
-  render_nodes ~partials ctx nodes
+  render_nodes_d ~partials ~depth:0 ctx nodes
 
 (** Render template to response *)
 let html ?(partials = no_partials) ctx template =

--- a/test/test_template_suite.ml
+++ b/test/test_template_suite.ml
@@ -74,6 +74,47 @@ let test_template_html_response () =
   check (option string) "content-type" (Some "text/html; charset=utf-8")
     (Kirin.Response.header "content-type" resp)
 
+(* Cyclic-partial guard regression tests. The cap stops a partial
+   resolver cycle from blowing the OCaml call stack. Without the cap,
+   [test_template_partial_cycle_terminates] below would stack-overflow
+   the test process instead of producing a string. *)
+
+let test_template_partial_resolves_normal () =
+  (* Non-cyclic partials still work — sanity / non-regression. *)
+  let partials = function
+    | "greeting" -> Some "Hello, {{name}}!"
+    | _ -> None
+  in
+  let ctx = `Assoc [("name", `String "world")] in
+  let out = Kirin.Template.render ~partials ctx "<p>{{> greeting}}</p>" in
+  check string "partial expanded" "<p>Hello, world!</p>" out
+
+let test_template_partial_cycle_terminates () =
+  (* Self-referential partial. Without the depth cap this stack-overflows. *)
+  let partials = function
+    | "loop" -> Some "x{{> loop}}"
+    | _ -> None
+  in
+  let ctx = `Assoc [] in
+  let out = Kirin.Template.render ~partials ctx "{{> loop}}" in
+  (* The cap fires before the stack does and the offending partial site
+     emits "". The surrounding "x" characters from successful inner
+     expansions accumulate, but bounded by max_partial_depth. *)
+  check bool "render returned without stack overflow" true (String.length out >= 0);
+  check bool "output length is bounded (< 1MB)" true (String.length out < 1_000_000)
+
+let test_template_partial_mutual_cycle_terminates () =
+  (* Two-step cycle: a -> b -> a -> ... Same depth-based termination. *)
+  let partials = function
+    | "a" -> Some "A{{> b}}"
+    | "b" -> Some "B{{> a}}"
+    | _ -> None
+  in
+  let ctx = `Assoc [] in
+  let out = Kirin.Template.render ~partials ctx "{{> a}}" in
+  check bool "render returned without stack overflow" true (String.length out >= 0);
+  check bool "output length is bounded" true (String.length out < 1_000_000)
+
 let tests = [
   test_case "simple variable" `Quick test_template_simple_var;
   test_case "html escape" `Quick test_template_html_escape;
@@ -87,4 +128,7 @@ let tests = [
   test_case "dot notation" `Quick test_template_dot_notation;
   test_case "interpolate" `Quick test_template_interpolate;
   test_case "html response" `Quick test_template_html_response;
+  test_case "partial resolves normally" `Quick test_template_partial_resolves_normal;
+  test_case "self-cycle terminates" `Quick test_template_partial_cycle_terminates;
+  test_case "mutual cycle terminates" `Quick test_template_partial_mutual_cycle_terminates;
 ]


### PR DESCRIPTION
## Why

Partials are resolved by a caller-supplied \`partials\` function. A cycle in that function — even an accidental one like

\`\`\`ocaml
fun "a" -> Some "{{> b}}"
fun "b" -> Some "{{> a}}"
\`\`\`

— recurses through \`render -> Partial -> render -> Partial -> ...\` and blows the OCaml call stack, taking the whole process down. The template author and the resolver author each think their piece is fine in isolation; nothing in the rendering loop pushes back.

This is an *availability* hole rather than a confidentiality one. \`partials\` is configured by application code, not by an end-user, so it's not directly attacker-controlled. But cyclic resolvers do happen in practice (a sidebar partial that mistakenly includes the layout, layout-of-layout reorg, etc.), and the failure mode is the worst possible one — full process crash from a single render call.

## What

- New \`max_partial_depth = 32\` constant. 32 is well past any hand-authored layout depth (typical: page -> layout -> sidebar -> snippet, ~4) but stops cycles cold.
- Internal mutually-recursive helpers \`render_nodes_d\` / \`render_node_d\` thread a \`depth\` counter. The counter increments **only when crossing a partial boundary**:
  - \`if\` / \`unless\` / \`each\` nesting is bounded by the static template size and is not resolver-influenced, so charging those would slow normal renders without buying safety.
- When \`depth >= max_partial_depth\` a \`Partial\` node logs a warning to stderr and emits \`\"\"\` for that one site. The surrounding template still renders — operators see a visible gap rather than a 500.
- Public \`render\` / \`render_node\` / \`render_nodes\` signatures stay unchanged. The depth-aware helpers are private; the public entries just call them at depth 0. **mli is unchanged.**

## Tests

3 new in \`test_template_suite.ml\`:

| Test | What it pins |
|---|---|
| \`partial resolves normally\` | non-regression for the happy path; cap must not block legitimate single-level partials |
| \`self-cycle terminates\` | \`\"loop\" -> \"x{{> loop}}\"\`; without the cap this stack-overflows the test process |
| \`mutual cycle terminates\` | two-step cycle \`a -> b -> a\`; depth counter resets correctly across different partial names within one chain |

The bound check (\`output length < 1MB\`) is how the test asserts termination — a non-terminating render either stack-overflows (alcotest reports a different failure) or produces an infinitely growing string. Either way the test fails loudly; the bound is the positive signal.

## Out of scope

- \`If\` / \`Each\` / \`Unless\` nesting cap — bounded by template size, not user-influenced.
- Resolver-side cycle detection (visited-set per render) — would catch *every* cycle but adds bookkeeping; depth cap is the cheaper guard that handles the same failure class for the same security outcome.
- Partial name validation / template-source allowlisting — different posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)