### PR TITLE
fix(etag): enforce RFC 7232 strong comparison on If-Match; SHA-256 digest

### DIFF
--- a/lib/etag.ml
+++ b/lib/etag.ml
@@ -36,17 +36,30 @@ let to_string = function
   | Strong s -> Printf.sprintf "\"%s\"" s
   | Weak s -> Printf.sprintf "W/\"%s\"" s
 
-(** Generate ETag from content using MD5 hash *)
+(* SHA-256 instead of MD5 for the content fingerprint.
+
+   ETag is nominally a cache validator, not a cryptographic identifier
+   — but the validator's only job is "different content => different
+   tag", which fails the moment a hash collision is achievable. MD5
+   collisions are practical, so an attacker who can influence cached
+   content can land two distinct bodies under the same ETag and cause
+   the cache to return stale or wrong content for a subsequent
+   request (cache poisoning). SHA-256 closes that without changing
+   the public API: the tag is opaque to clients and longer hex digits
+   are fine for any RFC-compliant ETag value. Existing cached entries
+   become one-shot misses on the upgrade — bounded cost. *)
+
+(** Generate ETag from content using SHA-256 hash *)
 let generate ?(weak = false) content =
-  let hash = Digestif.MD5.digest_string content in
-  let hex = Digestif.MD5.to_hex hash in
+  let hash = Digestif.SHA256.digest_string content in
+  let hex = Digestif.SHA256.to_hex hash in
   if weak then Weak hex else Strong hex
 
 (** Generate weak ETag from file stats (mtime + size) *)
 let generate_from_stats ~mtime ~size =
   let data = Printf.sprintf "%f-%d" mtime size in
-  let hash = Digestif.MD5.digest_string data in
-  let hex = Digestif.MD5.to_hex hash in
+  let hash = Digestif.SHA256.digest_string data in
+  let hex = Digestif.SHA256.to_hex hash in
   Weak hex
 
 (** Check if two ETags match
@@ -101,14 +114,27 @@ let middleware : (Request.t -> Response.t) -> (Request.t -> Response.t) =
       else
         resp
 
-(** Check precondition for If-Match (for PUT/DELETE) *)
+(** Check precondition for If-Match (for PUT/DELETE).
+
+    RFC 7232 §3.1: If-Match MUST use the strong comparison function.
+    The previous implementation reused [any_match] with its default
+    [~weak_comparison:true], so a client could send [If-Match: W/"v"]
+    against a server holding [Strong "v"] and pass the precondition.
+    That defeats the entire purpose of the header — concurrent
+    PUT/DELETE clients could race using only a weak validator, which
+    by definition may not have changed when the byte content did,
+    and the lost-update guard would silently let one of them through.
+
+    Now: strong comparison is enforced explicitly. Wildcard "*" still
+    matches anything per RFC §3.1. *)
 let check_if_match req current_etag =
   match Request.header "if-match" req with
   | None -> `Ok  (* No precondition *)
   | Some "*" -> `Ok  (* Wildcard matches anything *)
   | Some value ->
-    let client_etags = parse_if_none_match value in  (* Same parsing *)
-    if any_match client_etags current_etag then
+    let client_etags = parse_if_none_match value in
+    let strong_match etag = matches ~weak_comparison:false etag current_etag in
+    if List.exists strong_match client_etags then
       `Ok
     else
       `Precondition_failed  (* 412 *)

--- a/test/test_etag_suite.ml
+++ b/test/test_etag_suite.ml
@@ -72,6 +72,70 @@ let test_etag_middleware_304 () =
     check int "304 status" 304 (Kirin.Response.status_code resp2)
   | None -> failwith "no etag header"
 
+(* RFC 7232 §3.1 — If-Match MUST use strong comparison.
+
+   Before the fix, [check_if_match] reused [parse_if_none_match] +
+   [any_match] which defaulted to weak comparison, so a client could
+   pass W/"v" against Strong "v" and bypass the precondition. These
+   tests pin each side of the new strong-only semantics. *)
+
+let test_etag_if_match_strong_passes () =
+  let req = make_test_request
+    ~headers:[("if-match", "\"abc\"")]
+    ~meth:`PUT
+    "/" in
+  let result = Kirin.Etag.check_if_match req (Kirin.Etag.Strong "abc") in
+  check bool "strong client + strong server passes" true (result = `Ok)
+
+let test_etag_if_match_weak_rejected () =
+  (* RFC says: W/"v" against Strong "v" must NOT satisfy If-Match.
+     Two clients holding weak validators of "same" semantic content
+     cannot use that to coordinate a lost-update race. *)
+  let req = make_test_request
+    ~headers:[("if-match", "W/\"abc\"")]
+    ~meth:`PUT
+    "/" in
+  let result = Kirin.Etag.check_if_match req (Kirin.Etag.Strong "abc") in
+  check bool "weak client + strong server rejected" true
+    (result = `Precondition_failed)
+
+let test_etag_if_match_weak_to_weak_rejected () =
+  (* Even weak/weak is rejected under strong comparison: weak ETags
+     are explicitly outside the allowed set for If-Match. *)
+  let req = make_test_request
+    ~headers:[("if-match", "W/\"abc\"")]
+    ~meth:`PUT
+    "/" in
+  let result = Kirin.Etag.check_if_match req (Kirin.Etag.Weak "abc") in
+  check bool "weak/weak rejected for If-Match" true
+    (result = `Precondition_failed)
+
+let test_etag_if_match_wildcard_passes () =
+  let req = make_test_request
+    ~headers:[("if-match", "*")]
+    ~meth:`PUT
+    "/" in
+  let result = Kirin.Etag.check_if_match req (Kirin.Etag.Strong "anything") in
+  check bool "wildcard passes" true (result = `Ok);
+  let result_weak = Kirin.Etag.check_if_match req (Kirin.Etag.Weak "anything") in
+  check bool "wildcard passes even for weak server etag" true (result_weak = `Ok)
+
+let test_etag_if_match_absent_passes () =
+  let req = make_test_request ~meth:`PUT "/" in
+  let result = Kirin.Etag.check_if_match req (Kirin.Etag.Strong "anything") in
+  check bool "no header => no precondition" true (result = `Ok)
+
+let test_etag_generate_uses_sha256 () =
+  (* Pin the digest output size. SHA-256 hex is 64 chars; MD5 was 32.
+     A future refactor that quietly drops back to MD5 (smaller hash,
+     attractive perf number) would trip this. The pin makes the
+     digest choice load-bearing rather than incidental. *)
+  let etag = Kirin.Etag.generate "Hello, World!" in
+  match etag with
+  | Kirin.Etag.Strong s ->
+    check int "SHA-256 hex length" 64 (String.length s)
+  | _ -> failwith "expected strong etag"
+
 let tests = [
   test_case "parse strong etag" `Quick test_etag_parse_strong;
   test_case "parse weak etag" `Quick test_etag_parse_weak;
@@ -80,4 +144,10 @@ let tests = [
   test_case "etag matches" `Quick test_etag_matches;
   test_case "middleware adds etag" `Quick test_etag_middleware_adds_header;
   test_case "middleware 304" `Quick test_etag_middleware_304;
+  test_case "if-match strong passes" `Quick test_etag_if_match_strong_passes;
+  test_case "if-match weak rejected" `Quick test_etag_if_match_weak_rejected;
+  test_case "if-match weak/weak rejected" `Quick test_etag_if_match_weak_to_weak_rejected;
+  test_case "if-match wildcard passes" `Quick test_etag_if_match_wildcard_passes;
+  test_case "if-match absent passes" `Quick test_etag_if_match_absent_passes;
+  test_case "generate uses SHA-256" `Quick test_etag_generate_uses_sha256;
 ]


### PR DESCRIPTION
## Why

Two correctness/safety fixes in \`lib/etag.ml\`.

### 1. If-Match must use strong comparison (RFC 7232 §3.1)

\`check_if_match\` reused \`parse_if_none_match\` and \`any_match\`, which defaults to \`~weak_comparison:true\`. A client could send

\`\`\`
If-Match: W/\"v\"
\`\`\`

against a server holding \`Strong \"v\"\` and pass the precondition. That defeats the entire purpose of the header: two clients holding weak validators of \"same\" semantic content could race PUT/DELETE and the **lost-update guard would silently let one through**, even though weak validators are explicitly not sufficient for byte-equality reasoning.

The RFC is unambiguous here — §3.1 says If-Match \"MUST use the strong comparison function\". The fix is one line of intent change (\`matches ~weak_comparison:false\` instead of \`any_match\` default), plus a comment block explaining why for the next reader.

If-None-Match continues to use the default weak comparison — that header's semantics do allow it (§3.2).

### 2. SHA-256 instead of MD5 for the content fingerprint

ETag's job is \"different content → different tag\". MD5 collisions are practical, so an attacker who can influence cached content can land two distinct bodies under the same ETag and cause the cache to return stale or wrong content for a subsequent request — **cache poisoning** class.

ETag values are opaque to clients; 64 hex chars are within any RFC ETag value limit. Existing cached entries become one-shot misses on the upgrade — bounded cost.

## What

| Change | Surface |
|---|---|
| \`check_if_match\` uses \`matches ~weak_comparison:false\` | Strong comparison contract |
| \`generate\` / \`generate_from_stats\` use \`Digestif.SHA256\` | Cache validator collision class |

No \`.mli\` change. No caller change.

## Tests

6 new in \`test_etag_suite.ml\`:

| Test | Pins |
|---|---|
| if-match strong/strong passes | non-regression |
| if-match weak/strong **rejected** | the actual bug |
| if-match weak/weak **rejected** | strong-comparison contract |
| if-match wildcard passes (incl. weak server etag) | RFC §3.1 wildcard semantic |
| if-match absent passes | no precondition path |
| generate uses SHA-256 (length=64) | regression pin against MD5 revert |

The length pin on the digest is the part that makes the choice load-bearing: a future \"perf optimization\" that flips back to MD5 (32 hex) trips this test specifically rather than silently re-opening the collision class.

Full suite green.

## Out of scope

- Migrating the cache validator to a keyed HMAC (would prevent attacker-side collision construction more strongly than SHA-256 alone, but adds a key-management surface — separate posture decision).
- Streaming-body ETag generation (current middleware short-circuits on \`Stream\`/\`Producer\` bodies; that's a feature-level gap, not a security one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)