### PR TITLE
fix(auth/session): refresh cookie when a new session is minted, not when cookie was missing

### DIFF
--- a/lib/auth/session.ml
+++ b/lib/auth/session.ml
@@ -203,24 +203,47 @@ let clear_session_cookie ?(cookie_name = default_cookie_name) ?(path = "/") resp
 
 (** {1 Middleware} *)
 
-(** Session middleware - ensures session exists *)
+(** Session middleware - ensures session exists.
+
+    The set-cookie decision used to be gated on whether the *cookie*
+    was present on the request, not on whether a *new session* was
+    created. That left a server-side memory leak: when the cookie was
+    present but its session_id had expired (or been evicted by
+    [cleanup]), [store.get] returned None, the middleware fell
+    through to [create store ()], and a fresh session was created —
+    but the response arm saw "cookie was present" and did *not* call
+    [set_session_cookie]. The client kept walking around with the
+    dead ID, every subsequent request minted yet another fresh
+    session, and the in-memory store grew unboundedly. An attacker
+    holding any expired ID could pin server memory at request rate.
+
+    Track [is_new] explicitly so the cookie refresh follows the
+    "session was just created" event, not the "cookie was missing"
+    event. The two conditions used to coincide before expiry was
+    possible. *)
 let middleware ?(cookie_name = default_cookie_name) ?(create_if_missing = true)
     ?(secure = true) store =
   fun handler req ->
-    let session_id =
-      match get_id_from_request ~cookie_name req with
-      | Some id when Option.is_some (store.get id) -> id
-      | _ when create_if_missing -> create store ()
-      | _ -> ""
+    let cookie_id = get_id_from_request ~cookie_name req in
+    let existing_id =
+      match cookie_id with
+      | Some id when Option.is_some (store.get id) -> Some id
+      | _ -> None
+    in
+    let session_id, is_new =
+      match existing_id with
+      | Some id -> id, false
+      | None when create_if_missing -> create store (), true
+      | None -> "", false
     in
     if session_id = "" then
       handler req
     else
       let resp = handler req in
-      (* Set cookie if new session was created *)
-      match get_id_from_request ~cookie_name req with
-      | Some _ -> resp
-      | None -> set_session_cookie ~cookie_name ~secure session_id resp
+      if is_new then
+        set_session_cookie ~cookie_name ~secure session_id resp
+      else
+        resp
 
 (** Get session ID from request cookie *)
 let get_id ?(cookie_name = default_cookie_name) req =

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -128,10 +128,87 @@ let test_session_destroy () =
   check (option string) "destroyed session returns None" None
     (Kirin_auth.Session.get store id "key")
 
+(* Session middleware: cookie-refresh decision tests.
+
+   Regression for the expired-session memory leak: a request with a
+   cookie pointing at an *evicted* session_id used to mint a fresh
+   session server-side but not refresh the cookie. The client kept
+   the dead ID, each subsequent request minted another fresh
+   session, and the in-memory store grew unboundedly. The middleware
+   now sets the cookie whenever a *new* session was created — not
+   whenever the cookie was *missing*. *)
+
+let session_make_request ?(headers=[]) path =
+  let raw = Http.Request.make ~meth:`GET ~headers:(Http.Header.of_list headers) path in
+  let body_source =
+    Eio.Flow.string_source "" |> Eio.Buf_read.of_flow ~max_size:1024
+  in
+  Kirin.Request.make ~raw ~body_source
+
+let test_session_middleware_creates_cookie_when_missing () =
+  let store = Kirin_auth.Session.create_memory_store () in
+  let handler _req = Kirin.html "ok" in
+  let mw = Kirin_auth.Session.middleware ~secure:false store in
+  let req = session_make_request "/" in
+  let resp = mw handler req in
+  check bool "set-cookie issued for new session" true
+    (Option.is_some (Kirin.Response.header "set-cookie" resp))
+
+let test_session_middleware_no_refresh_when_valid () =
+  let store = Kirin_auth.Session.create_memory_store () in
+  let id = Kirin_auth.Session.create store () in
+  let handler _req = Kirin.html "ok" in
+  let mw = Kirin_auth.Session.middleware ~secure:false store in
+  let req = session_make_request
+    ~headers:[("cookie", "kirin_session=" ^ id)] "/" in
+  let resp = mw handler req in
+  check bool "no set-cookie for valid existing session" true
+    (Option.is_none (Kirin.Response.header "set-cookie" resp))
+
+let test_session_middleware_refreshes_cookie_after_expiry () =
+  (* This is the bug. Without the fix, set-cookie is absent here and
+     the client keeps walking around with the dead id forever, each
+     request minting yet another server-side session. *)
+  let store = Kirin_auth.Session.create_memory_store () in
+  let id = Kirin_auth.Session.create store () in
+  (* Simulate eviction: same effect as TTL expiry / cleanup from the
+     middleware's perspective. *)
+  Kirin_auth.Session.destroy store id;
+  let handler _req = Kirin.html "ok" in
+  let mw = Kirin_auth.Session.middleware ~secure:false store in
+  let req = session_make_request
+    ~headers:[("cookie", "kirin_session=" ^ id)] "/" in
+  let resp = mw handler req in
+  let set_cookie = Kirin.Response.header "set-cookie" resp in
+  check bool "set-cookie issued after expiry" true (Option.is_some set_cookie);
+  (* The new cookie must not echo the evicted id — otherwise the
+     client would still be pinned to a session that no longer exists. *)
+  match set_cookie with
+  | Some v ->
+    let needle = "kirin_session=" ^ id in
+    let len_v = String.length v in
+    let len_n = String.length needle in
+    let echoes_old =
+      let rec scan i =
+        if i + len_n > len_v then false
+        else if String.sub v i len_n = needle then true
+        else scan (i + 1)
+      in
+      scan 0
+    in
+    check bool "new cookie value differs from evicted id" false echoes_old
+  | None -> ()
+
 let session_tests = [
   test_case "create" `Quick (with_eio test_session_create);
   test_case "set/get" `Quick (with_eio test_session_set_get);
   test_case "destroy" `Quick (with_eio test_session_destroy);
+  test_case "middleware creates cookie when missing" `Quick
+    (with_eio test_session_middleware_creates_cookie_when_missing);
+  test_case "middleware no-refresh on valid session" `Quick
+    (with_eio test_session_middleware_no_refresh_when_valid);
+  test_case "middleware refreshes cookie after expiry" `Quick
+    (with_eio test_session_middleware_refreshes_cookie_after_expiry);
 ]
 
 (** {1 CSRF Tests} *)


### PR DESCRIPTION
## Why

The session middleware gated its set-cookie call on whether the **cookie** was present on the request, not on whether a **new session** was created server-side. Those two conditions used to coincide, but once expiry / cleanup eviction is possible they diverge — and the divergence leaks server memory unboundedly.

Repro: client holds a session_id cookie whose entry has been evicted (TTL expired, or \`cleanup\` ran). On the next request:

\`\`\`
1. get_id_from_request  -> Some old_id
2. store.get old_id     -> None  (expired/evicted)
3. middleware falls to  [create store ()], minting a fresh session
4. response arm checks  get_id_from_request again -> Some old_id
5. matches "Some _"     -> NO set-cookie
6. client still holds the dead id; server has a new dangling session
\`\`\`

Every subsequent request from that client repeats steps 1–6. The server-side store grows unboundedly, even though the client never sees a new session_id. **An attacker holding any expired id can pin server memory at request rate.** Benign clients with long-running tabs across a maintenance cleanup hit the same path more slowly.

## What

Track \`is_new\` explicitly. Set the cookie iff a new session was created:

\`\`\`ocaml
let session_id, is_new =
  match existing_id with
  | Some id -> id, false
  | None when create_if_missing -> create store (), true
  | None -> "", false
in
...
if is_new then set_session_cookie ... resp
else resp
\`\`\`

The two callers of \`create store ()\` (cookie missing **and** cookie present-but-expired) both flip \`is_new\` to true; the valid-existing-session path keeps it false so we don't rotate the id on every healthy request.

No \`.mli\` change. No caller change.

## Tests

3 new in \`test_auth.ml\` under Session:

| Test | Pins |
|---|---|
| middleware creates cookie when missing | non-regression for the no-cookie path (previously gated on absent cookie) |
| middleware no-refresh on valid session | non-regression: healthy sessions must NOT get a fresh cookie on every hit (would churn ids, break stateful clients) |
| middleware refreshes cookie after expiry | **the actual bug**: cookie present, store eviction simulated via \`destroy id\`, response must carry a set-cookie whose value does NOT echo the evicted id |

The third test would *not* pass on the prior code: the response had no set-cookie header at all, so the assertion \`Option.is_some set_cookie\` would fail. That's the regression signal.

Full suite: 33 auth tests pass; full kirin suite green.

## Out of scope

- Sliding-window expiry (re-arming \`last_accessed\` on each access is already in place; this PR doesn't change the eviction policy).
- Externally-backed stores: the leak shape is the same regardless of backend, but the test exercises the memory store which is the only built-in.
- Session fixation on regenerate — already addressed by the existing \`regenerate\` function; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)