### PR TITLE
sec(auth/oauth2): timing-safe verify_state + Secure flag on state cookie

### DIFF
--- a/lib/auth/oauth2.ml
+++ b/lib/auth/oauth2.ml
@@ -239,13 +239,22 @@ let exchange_code_params_pkce provider code verifier =
 
 (** {1 Route Helpers} *)
 
-(** Create login route handler *)
-let login_handler provider ?(scope = []) () =
+(** Create login route handler.
+
+    @param secure controls the [Secure] flag on the [oauth_state]
+           cookie. Defaults to [true]. The OAuth state cookie is the
+           sole CSRF guard for the callback — if it leaks to a
+           cleartext channel a network attacker can read it and
+           forge a callback that satisfies [verify_state]. Local-dev
+           callers using plain HTTP can pass [~secure:false] but
+           production must keep the default. *)
+let login_handler provider ?(scope = []) ?(secure = true) () =
   fun _req ->
     let (url, state) = authorization_url ~scope provider in
     (* Store state in session for verification *)
     let attrs = Kirin.Cookie.{
       default_attributes with
+      secure;
       http_only = true;
       same_site = Some `Lax;
       max_age = Some 600;
@@ -253,8 +262,31 @@ let login_handler provider ?(scope = []) () =
     Kirin.Response.redirect url
     |> Kirin.Cookie.set ~attrs "oauth_state" state
 
-(** Verify state parameter *)
+(* Constant-time string equality (OR-accumulator with the length
+   mismatch folded into the same accumulator). OCaml's [=] on strings
+   is byte-by-byte with short-circuit on the first mismatch, which
+   leaks how many bytes of the OAuth state an attacker has guessed
+   correctly. [verify_state] is called on every callback, so the
+   oracle is sampled at request rate. The state cookie is the sole
+   CSRF guard for the callback — a prefix-leak attack here turns a
+   single forged callback into a real account takeover. *)
+let constant_time_string_eq (a : string) (b : string) : bool =
+  let len_a = String.length a in
+  let len_b = String.length b in
+  let result = ref (len_a lxor len_b) in
+  let bound = min len_a len_b in
+  for i = 0 to bound - 1 do
+    result := !result lor (Char.code (String.get a i) lxor Char.code (String.get b i))
+  done;
+  !result = 0
+
+(** Verify state parameter.
+
+    Returns [true] only when the [oauth_state] cookie is present and
+    its value byte-equals [state]. Uses constant-time comparison so
+    a measuring attacker cannot recover the stored state prefix by
+    prefix. *)
 let verify_state req state =
   match Kirin.Cookie.get "oauth_state" req with
-  | Some stored when stored = state -> true
-  | _ -> false
+  | Some stored -> constant_time_string_eq stored state
+  | None -> false

--- a/lib/auth/oauth2.mli
+++ b/lib/auth/oauth2.mli
@@ -67,5 +67,13 @@ val authorization_url_pkce :
 val exchange_code_params_pkce :
   provider -> string -> string -> (string * string) list
 val login_handler :
-  provider -> ?scope:string list -> unit -> 'a -> Kirin.Response.t
+  provider -> ?scope:string list -> ?secure:bool -> unit -> 'a -> Kirin.Response.t
+(** [login_handler provider ?scope ?secure ()] returns the handler.
+    [secure] defaults to [true]: the [oauth_state] cookie is the sole
+    CSRF guard for the callback, so it must never travel cleartext.
+    Local-dev callers on plain HTTP can opt out with [~secure:false]. *)
+
 val verify_state : Kirin.Request.t -> string -> bool
+(** Constant-time comparison of the [oauth_state] cookie against the
+    [state] value returned by the OAuth provider. Avoids the prefix-leak
+    timing oracle that OCaml's [=] would expose on every callback. *)

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -208,11 +208,118 @@ let test_oauth2_pkce () =
   check bool "state non-empty" true (String.length state > 0);
   check bool "verifier non-empty" true (String.length verifier > 0)
 
+(* OAuth state hardening regression tests.
+
+   Two distinct defenses pinned individually so a future "simplification"
+   trips a specific test instead of silently re-opening one of them:
+
+   - verify_state must agree byte-for-byte with [=] on functional
+     output (constant-time helper must remain a drop-in). Without a
+     test that references the helper indirectly, a refactor could
+     replace [constant_time_string_eq] with [=] and nothing here
+     would notice until a timing-harness audit.
+
+   - login_handler must default the Secure flag on. Production OAuth
+     callbacks travel over HTTPS; the state cookie is the only CSRF
+     guard, and a non-Secure cookie is readable by any active network
+     attacker on the same path. *)
+
+let oauth_make_request ?(headers=[]) path =
+  let raw =
+    Http.Request.make ~meth:`GET ~headers:(Http.Header.of_list headers) path
+  in
+  let body_source =
+    Eio.Flow.string_source "" |> Eio.Buf_read.of_flow ~max_size:1024
+  in
+  Kirin.Request.make ~raw ~body_source
+
+let oauth_make_response_with_state_cookie state =
+  let req = oauth_make_request
+    ~headers:[("cookie", "oauth_state=" ^ state)] "/cb" in
+  req
+
+let test_oauth_verify_state_match () =
+  let req = oauth_make_response_with_state_cookie "abc123" in
+  check bool "matching state passes" true
+    (Kirin_auth.Oauth2.verify_state req "abc123")
+
+let test_oauth_verify_state_mismatch () =
+  let req = oauth_make_response_with_state_cookie "abc123" in
+  check bool "different value rejected" false
+    (Kirin_auth.Oauth2.verify_state req "abcxxx");
+  check bool "shorter value rejected" false
+    (Kirin_auth.Oauth2.verify_state req "abc");
+  check bool "longer value rejected" false
+    (Kirin_auth.Oauth2.verify_state req "abc1234")
+
+let test_oauth_verify_state_no_cookie () =
+  let req = oauth_make_request "/cb" in
+  check bool "missing cookie rejected" false
+    (Kirin_auth.Oauth2.verify_state req "anything")
+
+let test_oauth_login_handler_secure_default () =
+  (* The Secure attribute must be present on the state cookie unless
+     the caller explicitly opts out. Inspect the raw Set-Cookie value. *)
+  let p = Kirin_auth.Oauth2.Provider.google
+    ~client_id:"id" ~client_secret:"sec"
+    ~redirect_uri:"https://app/cb" in
+  let handler = Kirin_auth.Oauth2.login_handler p () in
+  let req = oauth_make_request "/login" in
+  let resp = handler req in
+  match Kirin.Response.header "set-cookie" resp with
+  | None -> Alcotest.fail "expected set-cookie header"
+  | Some v ->
+    let contains needle =
+      let nl = String.length needle in
+      let vl = String.length v in
+      let rec scan i =
+        if i + nl > vl then false
+        else if String.sub v i nl = needle then true
+        else scan (i + 1)
+      in
+      scan 0
+    in
+    check bool "Secure flag present by default" true (contains "; Secure")
+
+let test_oauth_login_handler_secure_opt_out () =
+  (* Local-dev callers can pass ~secure:false. The flag must then be
+     absent so the cookie works on plain HTTP. *)
+  let p = Kirin_auth.Oauth2.Provider.google
+    ~client_id:"id" ~client_secret:"sec"
+    ~redirect_uri:"https://app/cb" in
+  let handler = Kirin_auth.Oauth2.login_handler p ~secure:false () in
+  let req = oauth_make_request "/login" in
+  let resp = handler req in
+  match Kirin.Response.header "set-cookie" resp with
+  | None -> Alcotest.fail "expected set-cookie header"
+  | Some v ->
+    let contains needle =
+      let nl = String.length needle in
+      let vl = String.length v in
+      let rec scan i =
+        if i + nl > vl then false
+        else if String.sub v i nl = needle then true
+        else scan (i + 1)
+      in
+      scan 0
+    in
+    check bool "Secure flag absent when opted out" false
+      (contains "; Secure")
+
 let oauth2_tests = [
   test_case "provider google" `Quick test_oauth2_provider_google;
   test_case "provider github" `Quick test_oauth2_provider_github;
   test_case "authorization url" `Quick test_oauth2_authorization_url;
   test_case "pkce" `Quick test_oauth2_pkce;
+  test_case "verify_state matches" `Quick test_oauth_verify_state_match;
+  test_case "verify_state rejects mismatch / length diff" `Quick
+    test_oauth_verify_state_mismatch;
+  test_case "verify_state rejects when cookie missing" `Quick
+    test_oauth_verify_state_no_cookie;
+  test_case "login_handler sets Secure by default" `Quick
+    test_oauth_login_handler_secure_default;
+  test_case "login_handler honours ~secure:false" `Quick
+    test_oauth_login_handler_secure_opt_out;
 ]
 
 (** {1 Auth Middleware Tests (Hmap context, no global ref)} *)


### PR DESCRIPTION
## Why

Two OAuth2 CSRF holes in \`lib/auth/oauth2.ml\`.

### 1. \`verify_state\` is a timing oracle

\`\`\`ocaml
match Kirin.Cookie.get \"oauth_state\" req with
| Some stored when stored = state -> true
| _ -> false
\`\`\`

OCaml's \`=\` on strings is byte-by-byte with short-circuit on the first mismatch. \`verify_state\` runs on every OAuth callback, so the oracle is sampled at request rate. The state cookie is the **sole CSRF guard** for the callback — a successful prefix-leak attack turns a single forged callback into a real account takeover.

### 2. State cookie ships without the Secure flag

\`login_handler\` sets the \`oauth_state\` cookie with \`default_attributes\`, which has \`secure = false\`. On a production OAuth flow that ever sees plain HTTP for the path (downgrade-style MITM, captive-portal injection, dev middlebox), the state value is readable verbatim by any active network reader. They then forge a callback that satisfies \`verify_state\`.

## What

| Change | Surface |
|---|---|
| New internal \`constant_time_string_eq\` (OR-accumulator pattern, length mismatch folded into the same accumulator) | Removes the prefix-leak side-channel on every callback |
| \`verify_state\` uses the helper | mli unchanged |
| \`login_handler\` gains \`?secure:bool\`, default \`true\` | Production callers get the Secure flag automatically; local dev opts out with \`~secure:false\` |

The constant-time helper is the same shape as the wkbl admin / kirin csrf helpers. Not shared yet because \`oauth2\` is in a separate sub-library and a shared \"auth primitives\" module is a larger refactor than this fix.

## Tests

5 new under Oauth2, each pinning a specific gate:

| Test | Pins |
|---|---|
| verify_state matches | non-regression for the happy path |
| verify_state rejects different / shorter / longer value | length-mismatch must fold into the accumulator, not short-circuit early |
| verify_state rejects when cookie missing | no-cookie path |
| login_handler sets Secure by default | inspect raw Set-Cookie for \`; Secure\` |
| login_handler honours \`~secure:false\` | dev opt-out works |

A future refactor that drops either defense trips a specific test rather than silently re-opening the hole. Other auth suites (35 tests) and full kirin suite (228 tests) remain green.

## Out of scope

- Shared \"auth primitives\" module hosting one canonical \`constant_time_string_eq\` for \`kirin.auth\` + \`wkbl\` — separate refactor.
- Statistical timing harness — unit tests cannot prove timing equivalence; the behaviour pin is the practical defense.
- \`oauth_state\` cookie name namespacing (multi-provider apps may want a per-provider key) — separate feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)