### PR TITLE
fix(cache): reject NaN ttl, treat NaN expires_at as expired

### DIFF
--- a/lib/cache.ml
+++ b/lib/cache.ml
@@ -93,6 +93,21 @@ let now () = Unix.gettimeofday ()
 let with_lock mutex f =
   Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ())
 
+(* IEEE 754 NaN comparisons always evaluate to false, so an [expires_at]
+   that has gone through [now () +. nan] would make [is_expired] return
+   [false] *forever* — the entry stays pinned and silently leaks the
+   cache slot.  If the TTL is attacker-influenced (e.g. parsed from an
+   HTTP cache-control header) that is also a cache-poisoning vector.
+   Reject NaN at the boundary instead of letting it bleed into a
+   silent-failure path. *)
+let reject_nan_ttl ~caller t =
+  if Float.is_nan t then
+    invalid_arg (Printf.sprintf "Cache.%s: ttl is NaN" caller)
+
+let validate_ttl_option ~caller = function
+  | None -> ()
+  | Some t -> reject_nan_ttl ~caller t
+
 (** Update access counter for a key (O(1)) *)
 let touch_key cache key =
   cache.access_counter <- cache.access_counter + 1;
@@ -110,11 +125,16 @@ let find_lru_key cache =
   ) cache.access_times;
   !min_key
 
-(** Check if entry is expired *)
+(** Check if entry is expired.
+
+    Defense-in-depth against NaN [expires_at]: even if a NaN somehow
+    reaches the field (e.g. via a future code path that bypasses
+    [reject_nan_ttl]), treat it as expired so the slot is reclaimed on
+    the next read instead of remaining pinned forever. *)
 let is_expired entry =
   match entry.expires_at with
   | None -> false
-  | Some exp -> now () > exp
+  | Some exp -> Float.is_nan exp || now () > exp
 
 (** {1 Cache Creation} *)
 
@@ -124,6 +144,7 @@ let is_expired entry =
     @param default_ttl Default TTL in seconds (default: None = no expiration)
 *)
 let create ?(max_size = 1000) ?default_ttl ?(cleanup_interval = 60.0) () =
+  validate_ttl_option ~caller:"create" default_ttl;
   let config = { max_size; default_ttl; cleanup_interval } in
   let stats = {
     hits = 0;
@@ -180,6 +201,7 @@ let get cache key =
     @param ttl Optional TTL override (uses default_ttl if not specified)
 *)
 let set ?ttl cache key value =
+  validate_ttl_option ~caller:"set" ttl;
   with_lock cache.mutex (fun () ->
     let time = now () in
     let ttl = match ttl with
@@ -245,6 +267,7 @@ let mem cache key =
     storing the result we re-check under the lock; if another fiber
     already populated the entry we return the existing value. *)
 let get_or_set ?ttl cache key compute =
+  validate_ttl_option ~caller:"get_or_set" ttl;
   match get cache key with
   | Some v -> v
   | None ->

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -99,11 +99,69 @@ let test_per_entry_ttl_overrides_default () =
   Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
   check (option string) "per-entry ttl expired" None (Kirin.Cache.get cache "short")
 
+(* NaN TTL would make [is_expired] return false forever — every read
+   of [now () > nan] is false under IEEE 754.  The entry would stay
+   pinned and silently leak the cache slot; if the TTL is influenced
+   by external input (HTTP cache-control header, configuration file),
+   that is also a cache-poisoning vector.  Each entry point that takes
+   a TTL must reject NaN at the boundary. *)
+let test_set_rejects_nan_ttl () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  check_raises "set ~ttl:nan raises Invalid_argument"
+    (Invalid_argument "Cache.set: ttl is NaN")
+    (fun () -> Kirin.Cache.set ~ttl:Float.nan cache "k" "v");
+  (* Confirm nothing was inserted. *)
+  check int "cache untouched" 0 (Kirin.Cache.size cache)
+
+let test_get_or_set_rejects_nan_ttl () =
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  check_raises "get_or_set ~ttl:nan raises Invalid_argument"
+    (Invalid_argument "Cache.get_or_set: ttl is NaN")
+    (fun () ->
+      ignore (Kirin.Cache.get_or_set ~ttl:Float.nan cache "k"
+                (fun () -> "computed")));
+  check int "cache untouched" 0 (Kirin.Cache.size cache)
+
+let test_create_rejects_nan_default_ttl () =
+  Eio_main.run @@ fun _env ->
+  check_raises "create ~default_ttl:nan raises Invalid_argument"
+    (Invalid_argument "Cache.create: ttl is NaN")
+    (fun () ->
+      ignore (Kirin.Cache.create ~max_size:10 ~default_ttl:Float.nan ()))
+
+let test_infinity_ttl_treated_as_permanent () =
+  (* +infinity is the documented "never expires" extreme: [now () > inf]
+     is false, so the entry persists.  This pins that semantics as the
+     contract we keep after the NaN reject, and asserts the entry is
+     still readable after a real sleep. *)
+  Eio_main.run @@ fun env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set ~ttl:Float.infinity cache "k" "v";
+  Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
+  check (option string) "still here" (Some "v") (Kirin.Cache.get cache "k")
+
+let test_negative_infinity_ttl_expires_immediately () =
+  (* -infinity makes expires_at = -inf < now, so the entry is expired
+     on first read.  This pins the symmetric case so a future change
+     that "smartly clamps" negative TTL cannot regress into a permanent
+     entry. *)
+  Eio_main.run @@ fun _env ->
+  let cache = Kirin.Cache.create ~max_size:10 () in
+  Kirin.Cache.set ~ttl:Float.neg_infinity cache "k" "v";
+  check (option string) "instantly expired" None (Kirin.Cache.get cache "k")
+
 let ttl_tests = [
   test_case "ttl expiry" `Quick test_ttl_expiry;
   test_case "default ttl" `Quick test_default_ttl;
   test_case "no ttl never expires" `Quick test_no_ttl_never_expires;
   test_case "per-entry ttl overrides default" `Quick test_per_entry_ttl_overrides_default;
+  test_case "set rejects NaN ttl" `Quick test_set_rejects_nan_ttl;
+  test_case "get_or_set rejects NaN ttl" `Quick test_get_or_set_rejects_nan_ttl;
+  test_case "create rejects NaN default_ttl" `Quick test_create_rejects_nan_default_ttl;
+  test_case "infinity ttl never expires" `Quick test_infinity_ttl_treated_as_permanent;
+  test_case "negative infinity ttl expires immediately" `Quick test_negative_infinity_ttl_expires_immediately;
 ]
 
 (* -- LRU eviction -------------------------------------------------- *)


### PR DESCRIPTION
## 요약

`Kirin.Cache`의 TTL 경계에 NaN sanitization이 없어 silent failure가 가능했다. `set ~ttl:Float.nan`가 들어오면:

1. `expires_at = Some (now () +. nan) = Some nan`로 저장.
2. `is_expired`의 `now () > exp` 비교는 IEEE 754에 따라 NaN과의 모든 비교가 **false**.
3. 결과: entry가 *영원히* expire되지 않고 cache slot에 박혀버림.

영향:
- silent memory leak — eviction은 LRU로 reclaim되지만 그 전까지 sane TTL을 가정한 다른 entry보다 우선순위가 잘못 평가됨.
- TTL이 외부 입력(HTTP `Cache-Control: max-age`, 설정 파일 값 등)을 통해 영향을 받는 경로가 있다면 **cache poisoning** 벡터. 공격자가 NaN을 흘려넣을 수 있으면 stale value를 무기한 박아둘 수 있음.

## 변경

**`lib/cache.ml`**
- `reject_nan_ttl` 헬퍼 추가: `Float.is_nan t`면 `Invalid_argument` raise (silent failure 금지).
- 입력 TTL을 받는 모든 진입점에 `validate_ttl_option` 적용:
  - `create ~default_ttl`
  - `set ~ttl`
  - `get_or_set ~ttl`
- `is_expired`도 defense-in-depth로 보강 — 어떤 우회 경로로든 NaN `expires_at`가 도달하면 expired로 취급해 슬롯 회수.

**`test/test_cache.ml`** — 5 신규 테스트 (모두 ttl 그룹):
- `set ~ttl:nan` raises `Invalid_argument`, 캐시 사이즈 변화 없음.
- `get_or_set ~ttl:nan` raises, compute 호출 안 됨, 캐시 사이즈 변화 없음.
- `create ~default_ttl:nan` raises.
- `+infinity` TTL은 sleep 후에도 살아있음 (의도된 \"영구\" 시멘틱 pin).
- `-infinity` TTL은 즉시 만료 (대칭 케이스 pin — 미래에 \"음수 클램프\" fix가 들어와도 회귀 못 하게).

## 검증

- `dune exec --root . test/test_cache.exe` — 31 tests pass (기존 26 + 신규 5).
- Trope/anti-hype 가이드라인 준수 (텔레메트리-as-fix 아님, string 분류기 아님, N-of-M 아님 — boundary validation의 fail-loud 변환).

## RFC 면제

보안/안정성 boundary fix. RFC subsystem 매칭 없음 (auth/keeper/sandbox/dashboard credential 아님). `RFC-WAIVED: 경계 입력 검증, 외부 surface 변경 없음 (raise는 contract 추가).`

## Co-Authored-By

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>