### PR TITLE
fix(stream): reject CRLF/NUL/quote in filename and content_type

### DIFF
--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -115,22 +115,54 @@ let read_file_to_stream ~path ~chunk_size stream =
       in
       loop ())
 
+(* Both [filename] and [content_type] are interpolated straight into
+   HTTP response header values; CR/LF/NUL in either would split the
+   response and let a caller inject arbitrary headers (CWE-113).
+   The filename additionally lives inside a quoted-string in the
+   Content-Disposition form ["attachment; filename=\"...\""] — a bare
+   double-quote terminates that string and lets the caller append
+   directives in the same header (same shape, smaller blast radius).
+   Reject the dangerous bytes at the boundary like [cookie.ml] does
+   for Set-Cookie. *)
+let validate_header_value ~caller ~field value =
+  String.iter (fun c ->
+    match c with
+    | '\r' | '\n' | '\x00' ->
+      invalid_arg
+        (Printf.sprintf
+           "Stream.%s: %s contains disallowed byte 0x%02X"
+           caller field (Char.code c))
+    | _ -> ()
+  ) value
+
+let validate_filename_header ~caller filename =
+  validate_header_value ~caller ~field:"filename" filename;
+  String.iter (fun c ->
+    if c = '"' then
+      invalid_arg
+        (Printf.sprintf
+           "Stream.%s: filename contains disallowed byte 0x22 (quote)"
+           caller)
+  ) filename
+
 (** Create a file download response with streaming. *)
-let file_response ?filename ?content_type ?(chunk_size = default_chunk_size) path = 
-  let filename = match filename with 
-    | Some f -> f 
-    | None -> Filename.basename path 
-  in 
-  let content_type = match content_type with 
-    | Some ct -> ct 
-    | None -> mime_of_filename path 
-  in 
-  let headers = Http.Header.init () 
-    |> fun h -> Http.Header.add h "content-type" content_type 
-    |> fun h -> Http.Header.add h "content-disposition" 
-        (Printf.sprintf "attachment; filename=\"%s\"" filename) 
-    |> fun h -> Http.Header.add h "transfer-encoding" "chunked" 
-  in 
+let file_response ?filename ?content_type ?(chunk_size = default_chunk_size) path =
+  let filename = match filename with
+    | Some f -> f
+    | None -> Filename.basename path
+  in
+  validate_filename_header ~caller:"file_response" filename;
+  let content_type = match content_type with
+    | Some ct -> ct
+    | None -> mime_of_filename path
+  in
+  validate_header_value ~caller:"file_response" ~field:"content_type" content_type;
+  let headers = Http.Header.init ()
+    |> fun h -> Http.Header.add h "content-type" content_type
+    |> fun h -> Http.Header.add h "content-disposition"
+        (Printf.sprintf "attachment; filename=\"%s\"" filename)
+    |> fun h -> Http.Header.add h "transfer-encoding" "chunked"
+  in
   
   let stream_producer stream =
     Fun.protect ~finally:(fun () -> Eio.Stream.add stream None)
@@ -147,6 +179,7 @@ let file_inline ?content_type ?(chunk_size = default_chunk_size) path =
     | Some ct -> ct
     | None -> mime_of_filename path
   in
+  validate_header_value ~caller:"file_inline" ~field:"content_type" content_type;
   let headers = Http.Header.init ()
     |> fun h -> Http.Header.add h "content-type" content_type
     |> fun h -> Http.Header.add h "transfer-encoding" "chunked"

--- a/test/test_streaming.ml
+++ b/test/test_streaming.ml
@@ -177,8 +177,88 @@ let cancellation_tests = [
   test_case "producer normal completion" `Quick test_producer_normal_completion;
 ]
 
+(* Header-injection regression tests.
+
+   [Kirin.Stream.file_response]/[file_inline] interpolate caller-supplied
+   [filename] and [content_type] strings into HTTP response header
+   values via [Printf.sprintf]. CR/LF/NUL in either is CWE-113 response
+   splitting; a double-quote in [filename] terminates the
+   ["attachment; filename=\"...\""] quoted-string and lets the caller
+   inject extra Content-Disposition directives in the same header.
+
+   These tests pin each disallowed byte individually so a future
+   "simplification" that drops one case fails this suite instead of
+   the regression sitting silent until exploited. *)
+let expect_invalid_arg name f =
+  match f () with
+  | exception Invalid_argument _ -> ()
+  | _ -> failf "%s: expected Invalid_argument, got success" name
+
+let test_file_response_rejects_filename_crlf () =
+  Eio_main.run @@ fun _env ->
+  expect_invalid_arg "CR in filename"
+    (fun () -> Kirin.Stream.file_response ~filename:"a\rb" "/tmp/test");
+  expect_invalid_arg "LF in filename"
+    (fun () -> Kirin.Stream.file_response ~filename:"a\nb" "/tmp/test");
+  expect_invalid_arg "NUL in filename"
+    (fun () -> Kirin.Stream.file_response ~filename:"a\x00b" "/tmp/test")
+
+let test_file_response_rejects_filename_quote () =
+  (* A bare quote closes the Content-Disposition quoted-string and lets
+     the caller append directives. *)
+  Eio_main.run @@ fun _env ->
+  expect_invalid_arg "double-quote in filename"
+    (fun () -> Kirin.Stream.file_response ~filename:"a\";x=y" "/tmp/test")
+
+let test_file_response_rejects_content_type_crlf () =
+  Eio_main.run @@ fun _env ->
+  expect_invalid_arg "CRLF in content_type"
+    (fun () ->
+       Kirin.Stream.file_response
+         ~filename:"safe.txt"
+         ~content_type:"text/plain\r\nSet-Cookie: x=y"
+         "/tmp/test")
+
+let test_file_inline_rejects_content_type_crlf () =
+  Eio_main.run @@ fun _env ->
+  expect_invalid_arg "CRLF in inline content_type"
+    (fun () ->
+       Kirin.Stream.file_inline
+         ~content_type:"text/plain\r\nSet-Cookie: x=y"
+         "/tmp/test")
+
+let test_file_response_accepts_safe_filename () =
+  (* The validator must not be over-eager: ordinary names with spaces,
+     dots, hyphens, parens and non-ASCII bytes must still pass. *)
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
+  let resp =
+    Kirin.Stream.file_response
+      ~filename:"report (2026).pdf"
+      ~content_type:"application/pdf"
+      "/tmp/test"
+  in
+  (* Just observing that construction did not raise is the assertion;
+     the producer body is not executed because we never read it. *)
+  ignore resp;
+  check bool "constructed" true true
+
+let header_injection_tests = [
+  test_case "file_response rejects CRLF/NUL in filename" `Quick
+    test_file_response_rejects_filename_crlf;
+  test_case "file_response rejects double-quote in filename" `Quick
+    test_file_response_rejects_filename_quote;
+  test_case "file_response rejects CRLF in content_type" `Quick
+    test_file_response_rejects_content_type_crlf;
+  test_case "file_inline rejects CRLF in content_type" `Quick
+    test_file_inline_rejects_content_type_crlf;
+  test_case "file_response accepts safe filename" `Quick
+    test_file_response_accepts_safe_filename;
+]
+
 let () =
   run "Streaming" [
     "Eio Stream", streaming_tests;
     "Cancellation", cancellation_tests;
+    "Header Injection", header_injection_tests;
   ]


### PR DESCRIPTION
## 요약

\`Kirin.Stream.file_response\`와 \`Kirin.Stream.file_inline\`이 caller가 넘긴 \`?filename\` / \`?content_type\` 옵션 값을 \`Printf.sprintf\`로 HTTP 응답 헤더 값에 그대로 보간. 두 surface 모두에 CR/LF/NUL이 포함되면 **CWE-113 HTTP Response Splitting** — caller(또는 사용자가 path/query로 filename에 영향을 줄 수 있는 라우트)가 임의 응답 헤더(Set-Cookie 포함)를 주입 가능.

추가로 \`?filename\`의 경우 bare double-quote가 \`attachment; filename=\"...\"\` quoted-string을 종료시켜 같은 Content-Disposition 헤더 안에서 directive 주입 가능 — 같은 형태의 인젝션, blast radius만 작음.

## 변경

**\`lib/stream.ml\`**
- \`validate_header_value ~caller ~field\` 헬퍼 — CR/LF/NUL 한 바이트라도 발견하면 \`Invalid_argument\` raise (어떤 byte였는지 hex로 명시).
- \`validate_filename_header ~caller\` 헬퍼 — \`validate_header_value\` + \`\"\` 추가 reject (Content-Disposition quoted-string 경계).
- \`file_response\` — \`?filename\`은 \`validate_filename_header\`, \`?content_type\`은 \`validate_header_value\`.
- \`file_inline\` — \`?content_type\`은 \`validate_header_value\`.

같은 shape: \`Cookie.reject_header_injection\` (PR #109)와 동일 패턴 SSOT.

**\`test/test_streaming.ml\`** — 5 신규 테스트 (Header Injection 그룹):
- \`file_response\`가 filename의 CR/LF/NUL 각각을 reject.
- \`file_response\`가 filename의 \`\"\`를 reject.
- \`file_response\`가 content_type의 CRLF를 reject.
- \`file_inline\`이 content_type의 CRLF를 reject.
- (positive) \`file_response\`가 \`report (2026).pdf\` 같은 안전한 filename은 그대로 통과 — 검증이 over-eager가 아님을 핀.

각 disallowed byte를 개별 테스트로 핀해서 미래의 \"단순화\" PR이 한 케이스를 누락하면 회귀가 silent하지 않고 이 suite가 깨지도록 함.

## 검증

- \`dune exec --root . test/test_streaming.exe\` — 10 tests pass (기존 5 + 신규 5).

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix가 아님 — 입력 검증으로 실제 인젝션 surface를 *닫음*.
- ❌ string 분류기 추가가 아님 — \`String.iter\`로 byte-level reject. typed Result/variant 없는 surface (Http.Header.add는 string-only API).
- ❌ N-of-M 패치가 아님 — \`file_response\`/\`file_inline\` 두 함수 모두 같은 PR에서 동일 helper로 처리. caller 측 추가 검증은 별도 wrapper 책임.
- ❌ catch-all 추가가 아님.

## RFC

\`RFC-WAIVED: HTTP 응답 헤더 인젝션(CWE-113) boundary fix. credential/identity/operator/sandbox/dashboard credential 도메인 무관, 외부 API contract 추가만 (raise on invalid input).\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>