### PR TITLE
fix(cluster): backoff + crash-loop cap to stop supervisor fork-bombing

### DIFF
--- a/lib/cluster.ml
+++ b/lib/cluster.ml
@@ -30,6 +30,52 @@ type t = {
   master_pid : int;
 }
 
+(* Per-worker-id restart bookkeeping for the supervisor.
+
+   [last_spawn] is the wall-clock time of the most recent spawn for
+   that worker id.  [recent_crashes] counts consecutive crashes that
+   happened *faster than [min_restart_interval]* — the supervisor
+   uses this to detect a crash loop and give up before it pegs a CPU
+   forking dead children. *)
+type restart_state = {
+  mutable last_spawn : float;
+  mutable recent_crashes : int;
+}
+
+(** Minimum spacing between two spawns of the *same* worker id.  A
+    crash that happens faster than this counts toward
+    [max_consecutive_crashes] and triggers a sleep before the
+    respawn. *)
+let default_min_restart_interval = 1.0
+
+(** Hard cap on consecutive fast crashes for a single worker id
+    before the supervisor gives up and exits the master.  Without
+    this cap a worker that reliably raises on startup (port already
+    bound, config invalid, missing secret) would let the supervisor
+    fork-bomb the host. *)
+let default_max_consecutive_crashes = 10
+
+(** Pure decision: how long should the supervisor sleep before the
+    next respawn?  [<=0.0] means spawn immediately. *)
+let compute_backoff_delay ~last_spawn ~now ~min_restart_interval =
+  let elapsed = now -. last_spawn in
+  if elapsed >= min_restart_interval then 0.0
+  else min_restart_interval -. elapsed
+
+(** Pure decision: has this worker id crashed too many times in a row
+    fast enough to be considered an unrecoverable crash loop? *)
+let should_give_up ~recent_crashes ~max_consecutive_crashes =
+  recent_crashes >= max_consecutive_crashes
+
+(** Pure decision: update the recent-crash counter for the *current*
+    crash.  A crash that happened slower than [min_restart_interval]
+    resets the counter (the previous spawn is considered "stable
+    enough"); a fast crash increments it. *)
+let next_recent_crashes ~last_spawn ~now ~min_restart_interval ~recent_crashes =
+  let elapsed = now -. last_spawn in
+  if elapsed >= min_restart_interval then 1
+  else recent_crashes + 1
+
 (** Create a socket with SO_REUSEPORT *)
 let create_socket _port =
   let sock = socket PF_INET SOCK_STREAM 0 in
@@ -58,42 +104,123 @@ let spawn_worker id entry_point =
     { pid; id }
 
 (** Start the cluster *)
-let start ?(workers = 0) entry_point = 
+let start
+    ?(workers = 0)
+    ?(min_restart_interval = default_min_restart_interval)
+    ?(max_consecutive_crashes = default_max_consecutive_crashes)
+    entry_point =
   let num_workers = if workers > 0 then workers else Domain.recommended_domain_count () in
   Logger.info "[Master] Starting %d workers..." num_workers;
-  
+
   let cluster = {
     workers = Hashtbl.create num_workers;
     master_pid = getpid ();
   } in
 
+  (* Per-worker-id bookkeeping: how recently this slot last spawned,
+     and how many consecutive fast crashes it has accumulated.  Keyed
+     by worker [id], not [pid], because the [pid] changes on every
+     respawn but the slot identity is the [id]. *)
+  let restart_states : (int, restart_state) Hashtbl.t =
+    Hashtbl.create num_workers
+  in
+  let record_spawn id =
+    match Hashtbl.find_opt restart_states id with
+    | Some st -> st.last_spawn <- gettimeofday ()
+    | None ->
+      Hashtbl.add restart_states id
+        { last_spawn = gettimeofday (); recent_crashes = 0 }
+  in
+
   (* Spawn initial workers *)
   for i = 1 to num_workers do
     let w = spawn_worker i entry_point in
-    Hashtbl.add cluster.workers w.pid w
+    Hashtbl.replace cluster.workers w.pid w;
+    record_spawn w.id
   done;
 
+  (* Respawn one worker [id] with backoff + crash-loop cap.  Returns
+     [`Continue] on a normal respawn, [`Give_up] when the slot has
+     exceeded [max_consecutive_crashes] fast crashes — the supervisor
+     stops the master in that case rather than fork-bombing. *)
+  let respawn_with_backoff id =
+    let now = gettimeofday () in
+    let st =
+      match Hashtbl.find_opt restart_states id with
+      | Some st -> st
+      | None ->
+        let st = { last_spawn = now; recent_crashes = 0 } in
+        Hashtbl.add restart_states id st;
+        st
+    in
+    st.recent_crashes <-
+      next_recent_crashes
+        ~last_spawn:st.last_spawn
+        ~now
+        ~min_restart_interval
+        ~recent_crashes:st.recent_crashes;
+    if should_give_up
+         ~recent_crashes:st.recent_crashes
+         ~max_consecutive_crashes
+    then begin
+      Logger.error
+        "[Master] Worker %d crashed %d times in under %.1fs each — giving up"
+        id st.recent_crashes min_restart_interval;
+      `Give_up
+    end else begin
+      let delay =
+        compute_backoff_delay
+          ~last_spawn:st.last_spawn
+          ~now
+          ~min_restart_interval
+      in
+      if delay > 0.0 then begin
+        Logger.warn
+          "[Master] Worker %d respawning too fast — sleeping %.2fs (crash #%d)"
+          id delay st.recent_crashes;
+        sleepf delay
+      end;
+      let new_w = spawn_worker id entry_point in
+      Hashtbl.replace cluster.workers new_w.pid new_w;
+      st.last_spawn <- gettimeofday ();
+      `Continue
+    end
+  in
+
   (* Supervisor loop *)
-  let rec loop () = 
-    try 
-      let pid, status = wait () in 
-      match Hashtbl.find_opt cluster.workers pid with 
-      | Some w -> 
+  let rec loop () =
+    try
+      let pid, status = wait () in
+      match Hashtbl.find_opt cluster.workers pid with
+      | Some w ->
         Hashtbl.remove cluster.workers pid;
-        let reason = match status with 
+        let reason = match status with
           | WEXITED c -> Printf.sprintf "exit code %d" c
           | WSIGNALED s -> Printf.sprintf "signal %d" s
           | WSTOPPED s -> Printf.sprintf "stopped %d" s
-        in 
+        in
         Logger.warn "[Master] Worker %d (PID %d) died: %s. Respawning..." w.id pid reason;
-        let new_w = spawn_worker w.id entry_point in 
-        Hashtbl.add cluster.workers new_w.pid new_w;
-        loop ()
+        (match respawn_with_backoff w.id with
+         | `Continue -> loop ()
+         | `Give_up ->
+           Logger.error
+             "[Master] Aborting cluster: worker %d in unrecoverable crash loop"
+             w.id;
+           (* Surface the give-up to the caller of [start] instead of
+              silently looping; let the deployment supervisor
+              (systemd, k8s, etc.) decide whether to restart the
+              master from scratch. *)
+           raise Exit)
       | None -> loop () (* Unknown child? *)
-    with 
+    with
+    | Exit -> raise Exit
     | Unix_error (EINTR, _, _) -> loop ()
-    | e -> 
+    | e ->
       Logger.error "[Master] Supervisor error: %s" (Printexc.to_string e);
+      (* Sleep on unknown supervisor errors so a recurring failure
+         (e.g. ECHILD after every worker is gone) does not spin the
+         CPU re-entering [loop] thousands of times a second. *)
+      sleepf min_restart_interval;
       loop ()
-  in 
-  loop () 
+  in
+  try loop () with Exit -> ()

--- a/lib/cluster.mli
+++ b/lib/cluster.mli
@@ -36,12 +36,61 @@ val spawn_worker : int -> (unit -> unit) -> worker
 
 (** {1 Cluster Operations} *)
 
-(** [start ?workers entry_point] starts the cluster.
+(** Minimum spacing between two spawns of the same worker id (default
+    1.0s).  Used as the [min_restart_interval] default for [start]. *)
+val default_min_restart_interval : float
+
+(** Hard cap on consecutive fast crashes for a single worker id
+    before the supervisor gives up (default 10).  Used as the
+    [max_consecutive_crashes] default for [start]. *)
+val default_max_consecutive_crashes : int
+
+(** [compute_backoff_delay ~last_spawn ~now ~min_restart_interval]
+    returns how long the supervisor should sleep before respawning.
+    Returns [<= 0.0] when the worker has been alive at least
+    [min_restart_interval] (spawn immediately). *)
+val compute_backoff_delay :
+  last_spawn:float -> now:float -> min_restart_interval:float -> float
+
+(** [should_give_up ~recent_crashes ~max_consecutive_crashes] returns
+    [true] once a slot has crashed faster than [min_restart_interval]
+    that many times in a row.  The supervisor then exits the master
+    rather than continue fork-bombing the host. *)
+val should_give_up :
+  recent_crashes:int -> max_consecutive_crashes:int -> bool
+
+(** [next_recent_crashes ~last_spawn ~now ~min_restart_interval
+    ~recent_crashes] returns the updated fast-crash counter after a
+    crash.  A crash that took longer than [min_restart_interval]
+    resets the counter to [1]; a faster crash increments. *)
+val next_recent_crashes :
+  last_spawn:float ->
+  now:float ->
+  min_restart_interval:float ->
+  recent_crashes:int ->
+  int
+
+(** [start ?workers ?min_restart_interval ?max_consecutive_crashes
+    entry_point] starts the cluster.
 
     Forks [workers] child processes, each running [entry_point].
-    The master process supervises and respawns crashed workers.
+    The master process supervises and respawns crashed workers,
+    inserting a sleep when the same slot crashes within
+    [min_restart_interval] seconds and giving up after
+    [max_consecutive_crashes] consecutive fast crashes — without
+    these guards a worker that reliably raises on startup (port
+    already bound, config invalid) would let the supervisor
+    fork-bomb the host.
 
-    This function does not return (runs a supervisor loop).
+    Returns when the cluster gives up; the caller's deployment
+    supervisor (systemd, k8s) decides what to do next.
 
-    @param workers Number of worker processes (default: CPU count) *)
-val start : ?workers:int -> (unit -> unit) -> unit
+    @param workers Number of worker processes (default: CPU count)
+    @param min_restart_interval Minimum gap before respawn (default 1.0s)
+    @param max_consecutive_crashes Cap on fast-crash loop (default 10) *)
+val start :
+  ?workers:int ->
+  ?min_restart_interval:float ->
+  ?max_consecutive_crashes:int ->
+  (unit -> unit) ->
+  unit

--- a/test/dune
+++ b/test/dune
@@ -8,7 +8,7 @@
           test_graphql_suite test_pool_suite test_backpressure_suite
           test_cache_suite test_jobs_suite test_parallel_suite
           test_health_suite test_metrics_suite test_shutdown_suite
-          test_webrtc_suite test_query_suite)
+          test_webrtc_suite test_query_suite test_cluster_suite)
  (libraries kirin alcotest grpc-direct-core eio eio_main str unix))
 
 (test

--- a/test/test_cluster_suite.ml
+++ b/test/test_cluster_suite.ml
@@ -1,0 +1,126 @@
+(** Cluster supervisor decision tests.
+
+    These pin the pure [compute_backoff_delay] / [should_give_up] /
+    [next_recent_crashes] helpers that the supervisor loop drives.
+    The supervisor loop itself forks subprocesses and is integration-
+    territory; pinning the decisions in isolation catches the
+    fork-bomb regression — a crash loop that respawns immediately —
+    without the test having to fork. *)
+
+open Alcotest
+
+(* -- compute_backoff_delay ---------------------------------------- *)
+
+let test_backoff_zero_when_alive_long_enough () =
+  (* Worker lived [min_restart_interval] seconds → no sleep. *)
+  let d =
+    Kirin.Cluster.compute_backoff_delay
+      ~last_spawn:100.0
+      ~now:101.5
+      ~min_restart_interval:1.0
+  in
+  check (float 0.0001) "no backoff" 0.0 d
+
+let test_backoff_positive_on_fast_crash () =
+  (* Worker crashed 0.3s after spawn under a 1.0s interval →
+     supervisor must sleep ~0.7s before the next spawn. *)
+  let d =
+    Kirin.Cluster.compute_backoff_delay
+      ~last_spawn:100.0
+      ~now:100.3
+      ~min_restart_interval:1.0
+  in
+  check (float 0.0001) "0.7s delay" 0.7 d
+
+let test_backoff_zero_at_exact_boundary () =
+  (* elapsed == min_restart_interval → no sleep (>= in the impl). *)
+  let d =
+    Kirin.Cluster.compute_backoff_delay
+      ~last_spawn:0.0
+      ~now:1.0
+      ~min_restart_interval:1.0
+  in
+  check (float 0.0001) "boundary is fast-enough" 0.0 d
+
+(* -- should_give_up ------------------------------------------------ *)
+
+let test_give_up_under_cap () =
+  check bool "below cap" false
+    (Kirin.Cluster.should_give_up ~recent_crashes:9 ~max_consecutive_crashes:10)
+
+let test_give_up_at_cap () =
+  check bool "at cap" true
+    (Kirin.Cluster.should_give_up ~recent_crashes:10 ~max_consecutive_crashes:10)
+
+let test_give_up_above_cap () =
+  check bool "above cap" true
+    (Kirin.Cluster.should_give_up ~recent_crashes:11 ~max_consecutive_crashes:10)
+
+(* -- next_recent_crashes ------------------------------------------ *)
+
+let test_recent_crashes_resets_on_stable_run () =
+  (* A spawn that lived through the interval is "stable enough" —
+     the fast-crash counter resets to 1 on the next crash, not
+     [recent + 1].  This is how the supervisor avoids declaring
+     a crash loop after a long-running worker finally crashes once. *)
+  let n =
+    Kirin.Cluster.next_recent_crashes
+      ~last_spawn:0.0
+      ~now:5.0
+      ~min_restart_interval:1.0
+      ~recent_crashes:9
+  in
+  check int "reset to 1" 1 n
+
+let test_recent_crashes_increments_on_fast_crash () =
+  let n =
+    Kirin.Cluster.next_recent_crashes
+      ~last_spawn:0.0
+      ~now:0.2
+      ~min_restart_interval:1.0
+      ~recent_crashes:3
+  in
+  check int "incremented" 4 n
+
+(* The end-to-end invariant the supervisor needs: a worker that
+   reliably crashes faster than [min_restart_interval] must hit the
+   give-up condition within [max_consecutive_crashes] respawns.
+   Simulate that without forking. *)
+let test_crash_loop_gives_up_within_cap () =
+  let min_restart_interval = 1.0 in
+  let max_consecutive_crashes = 5 in
+  let crashes = ref 0 in
+  let last_spawn = ref 0.0 in
+  let now = ref 0.1 in (* crashes 0.1s after every spawn *)
+  let rec step () =
+    crashes :=
+      Kirin.Cluster.next_recent_crashes
+        ~last_spawn:!last_spawn
+        ~now:!now
+        ~min_restart_interval
+        ~recent_crashes:!crashes;
+    if Kirin.Cluster.should_give_up
+         ~recent_crashes:!crashes
+         ~max_consecutive_crashes
+    then !crashes
+    else begin
+      (* simulate spawn at [now], crash at [now + 0.1] *)
+      last_spawn := !now;
+      now := !now +. 0.1;
+      step ()
+    end
+  in
+  let final = step () in
+  check int "give up at cap" max_consecutive_crashes final
+
+let tests = [
+  test_case "no backoff after stable run" `Quick test_backoff_zero_when_alive_long_enough;
+  test_case "backoff on fast crash" `Quick test_backoff_positive_on_fast_crash;
+  test_case "no backoff at exact boundary" `Quick test_backoff_zero_at_exact_boundary;
+  test_case "give_up under cap" `Quick test_give_up_under_cap;
+  test_case "give_up at cap" `Quick test_give_up_at_cap;
+  test_case "give_up above cap" `Quick test_give_up_above_cap;
+  test_case "recent_crashes resets after stable run" `Quick test_recent_crashes_resets_on_stable_run;
+  test_case "recent_crashes increments on fast crash" `Quick test_recent_crashes_increments_on_fast_crash;
+  test_case "crash loop hits cap" `Quick test_crash_loop_gives_up_within_cap;
+]

--- a/test/test_kirin.ml
+++ b/test/test_kirin.ml
@@ -33,4 +33,5 @@ let () =
     ("Query", Test_query_suite.query_tests);
     ("Migrate", Test_query_suite.migrate_tests);
     ("Db", Test_query_suite.db_tests);
+    ("Cluster", Test_cluster_suite.tests);
   ]


### PR DESCRIPTION
## 요약

\`Kirin.Cluster.start\`의 supervisor loop이 worker가 죽으면 *즉시* respawn (지연 0, cap 없음). worker의 \`entry_point\`가 reliably raise하는 환경 (port already bound, config invalid, missing secret, env var typo) 에선 master가 instant fork/exec/exit 루프 → CPU 100% + PID table 폭주 + OOM fork-bomb 위험. systemd \`StartLimitBurst\`/\`StartLimitInterval\`이 존재하는 이유와 같은 supervisor 안티패턴.

## 변경

**\`lib/cluster.ml\` + \`lib/cluster.mli\`**

per worker-id 부기 추가 (last spawn time + fast-crash counter). counter는 *fast crash* (elapsed < min_restart_interval)일 때만 증가, stable run 후 crash는 counter를 1로 reset.

respawn 시점에:
- \`compute_backoff_delay\`로 \`min_restart_interval - elapsed\`만큼 sleep
- \`should_give_up\`로 \`max_consecutive_crashes\` 연속 fast crash면 master 종료 (\`raise Exit\`) — 외부 deployment supervisor (systemd, k8s) 가 cluster 전체 재시작 여부 결정

추가 보강 (편집 중 발견된 latent 결함):
- \`Hashtbl.add\` → \`Hashtbl.replace\` (PID wraparound 시 entry shadow 방지)
- catch-all supervisor error handler가 \`min_restart_interval\`만큼 sleep — recurring \`wait\`/ECHILD가 loop를 초당 수천 회 spinning 못 하게 함

결정 함수 3개 (\`compute_backoff_delay\`, \`should_give_up\`, \`next_recent_crashes\`) 는 *pure*하게 추출해 mli에 노출 — fork 없이 unit-testable.

**\`test/test_cluster_suite.ml\`** (신규, 9 test) — \`test_kirin\` suite에 \`Cluster\` 그룹으로 통합:

- \`compute_backoff_delay\`: stable run 후 0, 정확히 boundary에서 0, fast crash 시 양수 remainder
- \`should_give_up\`: cap 미만 / 정확히 cap / cap 초과 3 케이스
- \`next_recent_crashes\`: stable run 후 reset to 1, fast crash 시 increment
- 시뮬레이션 end-to-end: 0.1s lifetime crash loop이 \`max_consecutive_crashes\` 반복 안에 give-up 도달함을 fork 없이 핀

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **237 tests pass** (기존 228 + 신규 9).
- Cluster 그룹 9/9 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix가 아님 — fork-bomb 자체를 *차단* (sleep + give-up exit). 단순 카운터 증가 아님.
- ❌ string 분류기 아님 — typed pure helper들.
- ❌ N-of-M 패치 아님 — supervisor loop 단일 callsite.
- ✅ cap/cooldown 패턴 사용 — 하지만 *symptom 억제용 cap이 아니라 fork-bomb의 root resource bound*. PR body에 deprecation 경로 없음 (이게 정상 동작이므로). RFC 매칭 없음.

## RFC

\`RFC-WAIVED: process supervisor resource bound (fork-bomb prevention), 외부 API에 옵션 추가 (backwards compatible).\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>