### PR TITLE
fix(jobs): actually apply retry_delay between retries

### DIFF
--- a/lib/jobs.ml
+++ b/lib/jobs.ml
@@ -128,7 +128,24 @@ let take_job t =
     };
     Some job
 
-(** Process a single job, updating state under mutex on completion. *)
+(* [retry_delay] in [config] used to be dead config: the retry branch
+   re-queued the job synchronously, so a task that always raises was
+   retried [max_retries] times instantly — pinning a worker into a
+   tight retry spin and starving the rest of the queue.  Same shape
+   as the fork-bomb supervisor anti-pattern but at the fiber level.
+
+   Fix: split the post-task work into two phases.
+
+   1. Under the mutex, decide what to do ([`Done] for success or
+      final failure; [`Retry] when the job has retries left) and
+      record any state that does not depend on the sleep.
+   2. Outside the mutex, if [`Retry] was chosen, sleep for
+      [retry_delay] then re-acquire the mutex and re-queue.
+
+   Sleeping outside the mutex lets other workers keep draining the
+   queue while this one waits.  [running] is rechecked after the
+   sleep so [stop] takes effect promptly. *)
+
 let process_job t job =
   let result =
     try Ok (job.task ())
@@ -136,42 +153,67 @@ let process_job t job =
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> Error exn
   in
-  Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
-    match result with
-    | Ok value ->
-      job.status <- Completed value;
-      job.completed_at <- Some (Eio.Time.now t.clock);
-      Hashtbl.replace t.results job.id (Completed value);
-      t.stats <- {
-        t.stats with
-        total_completed = t.stats.total_completed + 1;
-        currently_running = t.stats.currently_running - 1;
-      };
-      Eio.Condition.broadcast t.job_completed
-    | Error exn ->
-      job.retries <- job.retries + 1;
-      if job.retries < job.max_retries then begin
+  let action =
+    Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+      match result with
+      | Ok value ->
+        job.status <- Completed value;
+        job.completed_at <- Some (Eio.Time.now t.clock);
+        Hashtbl.replace t.results job.id (Completed value);
+        t.stats <- {
+          t.stats with
+          total_completed = t.stats.total_completed + 1;
+          currently_running = t.stats.currently_running - 1;
+        };
+        Eio.Condition.broadcast t.job_completed;
+        `Done
+      | Error exn ->
+        job.retries <- job.retries + 1;
+        if job.retries < job.max_retries then begin
+          (* Defer the actual re-queue until after the retry-delay
+             sleep so a task that always raises cannot spin a worker
+             through every retry attempt instantly.  Account for the
+             job as no-longer-running now; it will get re-counted
+             into [queue_size] when we re-enqueue below. *)
+          t.stats <- {
+            t.stats with
+            currently_running = t.stats.currently_running - 1;
+          };
+          `Retry
+        end else begin
+          job.status <- Failed exn;
+          job.completed_at <- Some (Eio.Time.now t.clock);
+          Hashtbl.replace t.results job.id (Failed exn);
+          t.stats <- {
+            t.stats with
+            total_failed = t.stats.total_failed + 1;
+            currently_running = t.stats.currently_running - 1;
+          };
+          Eio.Condition.broadcast t.job_completed;
+          `Done
+        end
+    )
+  in
+  match action with
+  | `Done -> ()
+  | `Retry ->
+    if t.config.retry_delay > 0.0 then
+      Eio.Time.sleep t.clock t.config.retry_delay;
+    Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+      if t.running then begin
         job.status <- Pending;
         Hashtbl.replace t.results job.id Pending;
         t.jobs <- insert_by_priority job t.jobs;
         t.stats <- {
           t.stats with
-          currently_running = t.stats.currently_running - 1;
           queue_size = t.stats.queue_size + 1;
         };
         Eio.Condition.broadcast t.job_available
-      end else begin
-        job.status <- Failed exn;
-        job.completed_at <- Some (Eio.Time.now t.clock);
-        Hashtbl.replace t.results job.id (Failed exn);
-        t.stats <- {
-          t.stats with
-          total_failed = t.stats.total_failed + 1;
-          currently_running = t.stats.currently_running - 1;
-        };
-        Eio.Condition.broadcast t.job_completed
       end
-  )
+      (* If [stop] was called during the sleep, drop the retry on
+         the floor — the queue is shutting down and the result
+         table already shows the most recent failed attempt. *)
+    )
 
 (** Worker fiber loop: take jobs and process them until stopped. *)
 let worker_loop t =

--- a/test/test_jobs_suite.ml
+++ b/test/test_jobs_suite.ml
@@ -87,6 +87,91 @@ let test_jobs_priority () =
   check int "all queued" 3 stats.queue_size;
   J.stop queue
 
+(* Before this PR the [retry_delay] in [J.config] was dead config:
+   the retry branch in [process_job] re-queued failed jobs
+   synchronously, so a task that always raises burned through
+   [max_retries] in zero wall-clock time and pinned a worker into a
+   tight retry spin.  These tests pin the new behaviour:
+
+   - retry_delay is *actually applied* on each retry
+   - the job still eventually fails after [max_retries]
+   - other workers in the same queue are not blocked by a retrying
+     job (sleep happens outside the mutex) *)
+
+let test_retry_delay_is_applied () =
+  with_eio_jobs @@ fun ~sw ~clock ->
+  (* Single worker, 0.05s retry delay, max_retries=3.  A task that
+     always raises should take *at least* 2 × 0.05s = 0.1s of
+     wall-clock time before reaching the Failed state.  Without the
+     fix, the same workload completed in microseconds. *)
+  let queue = J.create ~sw ~clock ~workers:1 ~retry_delay:0.05 () in
+  let start = Eio.Time.now clock in
+  let result =
+    J.submit_and_wait
+      ~max_retries:3
+      queue
+      (fun () -> failwith "always fails")
+  in
+  let elapsed = Eio.Time.now clock -. start in
+  (match result with
+   | J.Failed _ -> ()
+   | _ -> fail "expected Failed after retries");
+  (* 3 attempts means 2 retries inserted, each preceded by a 0.05s
+     sleep.  Allow a small margin for scheduler jitter. *)
+  check bool
+    (Printf.sprintf "elapsed %.3fs >= 0.08s" elapsed)
+    true
+    (elapsed >= 0.08);
+  J.stop queue
+
+let test_retry_eventually_fails () =
+  with_eio_jobs @@ fun ~sw ~clock ->
+  let queue = J.create ~sw ~clock ~workers:1 ~retry_delay:0.0 () in
+  let attempts = ref 0 in
+  let result =
+    J.submit_and_wait
+      ~max_retries:3
+      queue
+      (fun () ->
+        incr attempts;
+        failwith "always fails")
+  in
+  (match result with
+   | J.Failed _ -> ()
+   | _ -> fail "expected Failed status");
+  check int "ran exactly max_retries attempts" 3 !attempts;
+  J.stop queue
+
+let test_retry_does_not_block_other_workers () =
+  with_eio_jobs @@ fun ~sw ~clock ->
+  (* Two workers, slow retry on the failing job, fast success on the
+     other.  If the retry-delay sleep were taken under the mutex the
+     succeeding job would have to wait at least one full delay
+     period; with the fix it should complete in well under that. *)
+  let queue = J.create ~sw ~clock ~workers:2 ~retry_delay:0.5 () in
+  let _failing =
+    J.submit
+      ~priority:J.Low
+      ~max_retries:5
+      queue
+      (fun () -> failwith "always fails")
+  in
+  (* Give the failing job a head start so it claims one of the two
+     workers and enters its retry sleep. *)
+  Eio.Time.sleep clock 0.02;
+  let succ_start = Eio.Time.now clock in
+  let succ_id = J.submit queue (fun () -> "ok") in
+  let res = J.wait queue succ_id in
+  let succ_elapsed = Eio.Time.now clock -. succ_start in
+  (match res with
+   | J.Completed v -> check string "got ok" "ok" v
+   | _ -> fail "expected Completed");
+  check bool
+    (Printf.sprintf "succeeding job completed in %.3fs (< 0.3s)" succ_elapsed)
+    true
+    (succ_elapsed < 0.3);
+  J.stop queue
+
 let tests = [
   test_case "jobs create" `Quick test_jobs_create;
   test_case "jobs submit" `Quick test_jobs_submit;
@@ -97,4 +182,7 @@ let tests = [
   test_case "jobs cancel" `Quick test_jobs_cancel;
   test_case "jobs clear" `Quick test_jobs_clear;
   test_case "jobs priority" `Quick test_jobs_priority;
+  test_case "retry_delay is applied" `Quick test_retry_delay_is_applied;
+  test_case "retry eventually fails after max_retries" `Quick test_retry_eventually_fails;
+  test_case "retry does not block other workers" `Quick test_retry_does_not_block_other_workers;
 ]


### PR DESCRIPTION
## 요약

\`Jobs.config.retry_delay\`가 **dead config**였음. \`process_job\`의 retry 분기 (lib/jobs.ml:152-162)가 실패한 job을 *mutex 안에서 동기적으로* re-queue. 결과:
- 항상 raise하는 task가 \`max_retries\` 번을 마이크로초 안에 소진.
- 그 worker fiber가 retry spin loop에 갇혀 *queue의 다른 job 처리를 차단*.
- Iter 57 \`Cluster\` supervisor fork-bomb 안티패턴의 fiber-level 버전.

WKBL이 retry-heavy workload (scraper retry, DB sync retry)에 \`Jobs\`를 쓸 경우, 항상 실패하는 외부 의존성 (down된 API) 하나가 worker pool 전체를 마비시킬 수 있었음.

## 변경

**\`lib/jobs.ml\`** — \`process_job\`을 두 단계로 split:

1. **Mutex 안에서 결정만**: \`\`Done\` (성공/최종실패) | \`\`Retry\` (재시도 남음). retry path는 \`currently_running\`만 감소시키고 *re-enqueue하지 않음*.
2. **Mutex 밖에서**: \`\`Retry\`이면 \`Eio.Time.sleep clock retry_delay\`, 그 다음 mutex 재획득해서 \`insert_by_priority\` + broadcast. sleep 도중 \`stop\`이 호출됐는지 \`t.running\`로 재확인.

Sleep을 mutex 밖에서 하기에 *다른 worker는 queue 계속 처리*. retry_delay=0.5인 failing job 옆에서 success job이 0.3s 안에 끝나는 것을 테스트로 핀.

**\`test/test_jobs_suite.ml\`** — 3 신규 (Jobs 그룹, 12 total):

- **\`retry_delay is applied\`**: \`retry_delay:0.05\`, \`max_retries:3\`, 항상 raise. 2번 retry × 0.05s = 최소 0.08s wall-clock. PR 전엔 마이크로초 안에 끝남.
- **\`retry eventually fails after max_retries\`**: retry path가 무한루프 없이 정확히 \`max_retries\` 시도 후 Failed 도달.
- **\`retry does not block other workers\`**: 2 workers. failing job (retry_delay:0.5)이 한 worker 점유한 상태에서 success job이 0.3s 안에 완료. sleep이 mutex 밖이라는 invariant 핀.

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **231 tests pass** (기존 228 + 신규 3).
- Jobs 그룹 12/12 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — *dead config*를 *실제 동작*으로 활성화.
- ❌ string 분류기 아님.
- ❌ N-of-M 아님.
- ❌ catch-all/cap 안티패턴 아님 — retry_delay는 user-configurable, 의도된 backpressure.

## RFC

\`RFC-WAIVED: dead config 활성화 + fiber-level retry-spin 차단. 외부 API contract는 \`retry_delay\` 동작만 변경 (값 0.0이면 기존 동작 유지로 backwards compatible — \`if retry_delay > 0.0 then sleep\`).\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>