### PR TITLE
fix(health): catch raising checks; honour manual drain in ready_handler

### DIFF
--- a/lib/health.ml
+++ b/lib/health.ml
@@ -48,11 +48,28 @@ let is_ready t =
   t.manual_ready
 (** {1 Check Logic} *)
 
+(* A registered check is a user-provided closure.  Before this PR
+   it was called directly inside [Hashtbl.fold], so a single check
+   that raised collapsed the entire aggregation — [/health],
+   [/healthz], [/ready] and friends all returned 500 and kubelet
+   saw the pod as crashed.  One buggy probe should not gate every
+   other probe; map a raised exception to an [Unhealthy] status
+   that names the failure and lets the remaining checks contribute.
+   [Eio.Cancel.Cancelled] is re-raised because that one *does*
+   need to unwind the fiber. *)
+let safe_run_check name check =
+  try check ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Unhealthy
+      (Printf.sprintf "check %S raised: %s" name (Printexc.to_string exn))
+
 (** Run all checks and aggregate status *)
-let check t = 
-  let results = Hashtbl.fold (fun name check acc -> 
-    (name, check ()) :: acc 
-  ) t.checks [] in 
+let check t =
+  let results = Hashtbl.fold (fun name check acc ->
+    (name, safe_run_check name check) :: acc
+  ) t.checks [] in
   
   let overall = List.fold_left (fun acc (_, status) -> 
     match acc, status with 
@@ -110,17 +127,39 @@ let live_handler _t =
     Response.make ~status:`OK ~headers:default_headers 
       (`String "{\"status\":\"alive\"}")
 
-(** Readiness probe handler (for /ready) *)
-let ready_handler t = 
-  fun _req -> 
-    let status, _ = check t in 
-    match status with 
-    | Healthy | Degraded _ -> 
-      Response.make ~status:`OK ~headers:default_headers 
-        (`String "{\"status\":\"ready\"}") 
-    | Unhealthy _ -> 
-      Response.make ~status:`Service_unavailable ~headers:default_headers 
-        (`String "{\"status\":\"not_ready\"}") 
+(** Pure: readiness verdict.
+
+    Honours both the manual [is_ready] flag *and* the aggregated
+    [check] result.  The manual flag exists for graceful K8s
+    rolling updates: an operator calls [set_ready t false] just
+    before SIGTERM so the kubelet starts draining traffic while
+    in-flight requests finish.  Before this PR the flag was a
+    silent no-op in [ready_handler] — [set_ready false] was
+    dropped because the handler only consulted [check].  Extracted
+    here as a pure verdict so callers can drive K8s probes (or
+    a custom transport) without depending on Kirin's Request/Response
+    types, and so the regression is unit-testable. *)
+let ready_status t : [ `Ready | `Not_ready_drain | `Not_ready_unhealthy ] =
+  if not (is_ready t) then `Not_ready_drain
+  else
+    let status, _ = check t in
+    match status with
+    | Healthy | Degraded _ -> `Ready
+    | Unhealthy _ -> `Not_ready_unhealthy
+
+(** Readiness probe handler (for /ready). *)
+let ready_handler t =
+  fun _req ->
+    match ready_status t with
+    | `Ready ->
+      Response.make ~status:`OK ~headers:default_headers
+        (`String "{\"status\":\"ready\"}")
+    | `Not_ready_drain ->
+      Response.make ~status:`Service_unavailable ~headers:default_headers
+        (`String "{\"status\":\"not_ready\",\"reason\":\"drain\"}")
+    | `Not_ready_unhealthy ->
+      Response.make ~status:`Service_unavailable ~headers:default_headers
+        (`String "{\"status\":\"not_ready\"}")
 
 (** {1 Routes} *)
 

--- a/lib/health.mli
+++ b/lib/health.mli
@@ -50,8 +50,22 @@ val is_ready : t -> bool
 (** [check t] runs all registered checks and returns the aggregated status
     along with a JSON object containing status, uptime, and per-check details.
     Status is [Unhealthy] if any check is unhealthy, [Degraded] if any is
-    degraded, [Healthy] otherwise. *)
+    degraded, [Healthy] otherwise.
+
+    A check that raises is converted into [Unhealthy "check \"name\"
+    raised: ..."] so one buggy probe cannot collapse the entire
+    aggregation.  [Eio.Cancel.Cancelled] is re-raised; that one
+    must unwind the fiber. *)
 val check : t -> status * Yojson.Safe.t
+
+(** [ready_status t] is the verdict that [ready_handler] uses,
+    exposed as a pure value:
+    - [`Ready] when [is_ready t] is [true] *and* [check t] is not
+      [Unhealthy];
+    - [`Not_ready_drain] when [is_ready t] is [false] (operator
+      drain in progress);
+    - [`Not_ready_unhealthy] when [check t] is [Unhealthy]. *)
+val ready_status : t -> [ `Ready | `Not_ready_drain | `Not_ready_unhealthy ]
 
 (** {1 HTTP Handlers} *)
 

--- a/test/test_health_suite.ml
+++ b/test/test_health_suite.ml
@@ -68,13 +68,98 @@ let test_health_uptime () =
   in
   check bool "uptime > 0" true (uptime > 0.0)
 
-let test_health_exception () =
+(* Before this PR, a raising check escaped through [Hashtbl.fold]
+   and collapsed the entire aggregation — every probe (/health,
+   /ready, /healthz, /readyz) returned 500 because of a single
+   buggy check, even when the other checks were fine.  The old
+   [test_health_exception] test pinned that *buggy* behaviour.
+   This test pins the new contract: a raised exception becomes a
+   named [Unhealthy] status, and the other registered checks still
+   contribute their own results. *)
+let test_health_exception_is_caught () =
   let health = H.create () in
   H.register health "throws" (fun () -> failwith "boom");
-  try
-    let _ = H.check health in
-    fail "expected exception"
-  with _ -> ()
+  H.register health "good" (fun () -> H.Healthy);
+  let status, json = H.check health in
+  (* Aggregate is Unhealthy because one check raised, but it must
+     not raise — the call returned cleanly. *)
+  (match status with
+   | H.Unhealthy _ -> ()
+   | _ -> fail "expected Unhealthy aggregate after one check raised");
+  (* The good check still produced a result; both names must be
+     present in the JSON details. *)
+  let details_names = match json with
+    | `Assoc fields ->
+      (match List.assoc_opt "details" fields with
+       | Some (`Assoc d) -> List.map fst d
+       | _ -> [])
+    | _ -> []
+  in
+  let names_sorted = List.sort compare details_names in
+  check (list string) "both checks present" ["good"; "throws"] names_sorted
+
+let test_health_exception_status_names_the_check () =
+  (* The Unhealthy message names the check that raised — operators
+     need to know which probe died without grepping logs. *)
+  let health = H.create () in
+  H.register health "db-primary" (fun () -> failwith "kaboom");
+  let status, _ = H.check health in
+  match status with
+  | H.Unhealthy msg ->
+    let has_substring s sub =
+      let n = String.length sub in
+      let m = String.length s in
+      let rec loop i =
+        if i + n > m then false
+        else if String.sub s i n = sub then true
+        else loop (i + 1)
+      in
+      loop 0
+    in
+    check bool "names the check" true (has_substring msg "db-primary");
+    check bool "names the failure" true (has_substring msg "kaboom")
+  | _ -> fail "expected Unhealthy"
+
+(* ready_status pure-verdict tests pin the regression where
+   [set_ready false] was a silent no-op in [ready_handler]
+   (manual drain dropped for the K8s graceful-shutdown flow). *)
+let test_ready_status_healthy () =
+  let health = H.create () in
+  H.register health "ok" (fun () -> H.Healthy);
+  match H.ready_status health with
+  | `Ready -> ()
+  | _ -> fail "expected `Ready"
+
+let test_ready_status_drain () =
+  let health = H.create () in
+  H.register health "ok" (fun () -> H.Healthy);
+  H.set_ready health false;
+  match H.ready_status health with
+  | `Not_ready_drain -> ()
+  | `Ready -> fail "drain flag was ignored — regression"
+  | `Not_ready_unhealthy -> fail "drain should report drain, not unhealthy"
+
+let test_ready_status_unhealthy_overrides_ready_flag () =
+  (* Manual ready=true must NOT mask a real unhealthy aggregate;
+     the K8s contract is that /ready only succeeds when both gates
+     are open. *)
+  let health = H.create () in
+  H.register health "broken" (fun () -> H.Unhealthy "fail");
+  H.set_ready health true;
+  match H.ready_status health with
+  | `Not_ready_unhealthy -> ()
+  | _ -> fail "expected `Not_ready_unhealthy"
+
+let test_ready_status_drain_wins_over_unhealthy () =
+  (* When both gates are closed, drain is the better signal for an
+     operator: the unhealthy check might be a downstream effect of
+     the shutdown.  Pin which signal wins. *)
+  let health = H.create () in
+  H.register health "broken" (fun () -> H.Unhealthy "fail");
+  H.set_ready health false;
+  match H.ready_status health with
+  | `Not_ready_drain -> ()
+  | _ -> fail "drain should win over unhealthy"
 
 let tests = [
   test_case "health create" `Quick test_health_create;
@@ -84,5 +169,10 @@ let tests = [
   test_case "health degraded" `Quick test_health_degraded;
   test_case "health ready control" `Quick test_health_ready_control;
   test_case "health uptime" `Quick test_health_uptime;
-  test_case "health exception" `Quick test_health_exception;
+  test_case "raised check is caught" `Quick test_health_exception_is_caught;
+  test_case "raised check is named in status" `Quick test_health_exception_status_names_the_check;
+  test_case "ready_status healthy" `Quick test_ready_status_healthy;
+  test_case "ready_status drain" `Quick test_ready_status_drain;
+  test_case "ready_status unhealthy overrides ready flag" `Quick test_ready_status_unhealthy_overrides_ready_flag;
+  test_case "ready_status drain wins over unhealthy" `Quick test_ready_status_drain_wins_over_unhealthy;
 ]


### PR DESCRIPTION
## 요약

\`Kirin.Health\`의 두 latent 결함을 한 PR로 fix (같은 code-path, 같은 test surface).

### 1. Raising check이 모든 probe를 collapse

\`check t\` (line 56)이 user-provided closure를 \`Hashtbl.fold\` 안에서 직접 호출. 한 probe가 raise하면 fold 전체가 escape → \`/health\` / \`/ready\` / \`/healthz\` / \`/readyz\` 모두 500. kubelet은 pod를 crash로 마크. 다른 probe가 healthy여도 한 buggy probe가 *전체 readiness*를 차단.

### 2. \`set_ready false\`가 silent no-op

\`set_ready\` / \`is_ready\`는 K8s rolling-update graceful drain용 (operator가 SIGTERM 직전 ready=false 플래그를 내려 kubelet이 traffic 라우팅 차단하기 시작). 그러나 \`ready_handler\` (line 118)은 \`is_ready\`를 *호출하지 않음* — \`check t\`만 호출. operator는 drain 했다고 믿지만 kubelet은 계속 traffic 보냄. iter 59의 jobs \`retry_delay\` dead config과 동일 패턴.

## 변경

**\`lib/health.ml\`** + **\`lib/health.mli\`**:

- \`safe_run_check\` helper — user closure를 try/with로 감싸 \`Unhealthy \"check \\\"name\\\" raised: ...\"\`로 매핑 (probe 이름 명시). \`Eio.Cancel.Cancelled\`는 re-raise (fiber unwind 필요).
- \`check\`이 \`safe_run_check\`을 통해 호출 — 한 probe 실패가 다른 probe 결과를 가리지 않음.
- \`ready_status t : [ \`Ready | \`Not_ready_drain | \`Not_ready_unhealthy ]\` pure verdict 추출 + mli 노출.
- \`ready_handler\`가 \`ready_status\`를 거쳐 결정. \`Not_ready_drain\`이 \`Not_ready_unhealthy\`보다 우선 — drain signal이 shutdown-induced unhealthy에 masking되지 않음.

\`ready_status\`는 mli 노출이라 K8s probe 이외의 custom transport (gRPC probe, sidecar bridge)에서도 같은 verdict 재사용 가능.

**\`test/test_health_suite.ml\`** — 기존 buggy invariant 1개 (raise 기대) 제거, 신규 6개 추가:

- \`raised check is caught\` — raise한 probe + healthy probe 동시 등록 시 둘 다 JSON details에 등장 + 전체 status는 Unhealthy (raise 아님).
- \`raised check is named in status\` — Unhealthy message가 probe name과 underlying failure를 *포함*.
- \`ready_status healthy\` — healthy + ready=true → \`Ready\`.
- \`ready_status drain\` — \`set_ready false\` 후 \`Not_ready_drain\` (drain flag silent drop 회귀 방지).
- \`ready_status unhealthy overrides ready flag\` — ready=true여도 unhealthy면 \`Not_ready_unhealthy\` (manual gate가 real failure를 mask하지 않음).
- \`ready_status drain wins over unhealthy\` — 두 gate 모두 closed면 drain이 더 정확한 operator 신호.

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **233 tests pass** (기존 228 + net +5).
- Health 그룹 13/13 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 실패 모드를 차단 (fold collapse + dead manual_ready).
- ❌ string 분류기 아님 — typed polymorphic variant verdict (\`Ready / \`Not_ready_drain / \`Not_ready_unhealthy).
- ❌ N-of-M 아님 — 두 결함을 한 PR에서 동일 module 안 두 진입점 모두 fix.
- ❌ catch-all 아님 — \`Eio.Cancel.Cancelled\`은 명시적으로 re-raise (fiber semantics 보존).

## RFC

\`RFC-WAIVED: K8s probe 안정성 fix. 외부 API는 \`ready_status\` 추가 노출만 (backwards compatible — \`ready_handler\` 동작 변경은 \`is_ready=true\` default에서 기존과 동일).\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>