### PR TITLE
fix(webrtc_signaling): server-mutex lookup; collect empty rooms

### DIFF
--- a/lib/webrtc_signaling.ml
+++ b/lib/webrtc_signaling.ml
@@ -127,16 +127,49 @@ let join_room server ~room_id ~peer_id =
   Eio.Mutex.use_rw ~protect:true room.mutex (fun () ->
     Hashtbl.replace room.peers peer_id ())
 
+(* Lock ordering: [server.mutex] first, then [room.mutex].
+   [get_or_create_room] / [leave_room] hold the server lock only
+   while looking up or mutating [server.rooms]; nobody holds
+   [room.mutex] while *acquiring* [server.mutex], so the
+   server-then-room ordering is the only direction taken and
+   no deadlock is possible. *)
+
 let leave_room server ~room_id ~peer_id =
-  match Hashtbl.find_opt server.rooms room_id with
-  | None -> ()
-  | Some room ->
-    Eio.Mutex.use_rw ~protect:true room.mutex (fun () ->
-      Hashtbl.remove room.peers peer_id)
+  (* Hold the server lock long enough to (a) find the room safely
+     against concurrent [join_room] mutation, and (b) collect the
+     room from [server.rooms] when the last peer leaves.  Without
+     the cleanup, a stream of unique [room_id]s — easy to drive
+     from untrusted Join messages — accumulates entries forever
+     and never frees them, even after every peer disconnects. *)
+  Eio.Mutex.use_rw ~protect:true server.mutex (fun () ->
+    match Hashtbl.find_opt server.rooms room_id with
+    | None -> ()
+    | Some room ->
+      Eio.Mutex.use_rw ~protect:true room.mutex (fun () ->
+        Hashtbl.remove room.peers peer_id;
+        if Hashtbl.length room.peers = 0 then
+          Hashtbl.remove server.rooms room_id))
 
 let get_peers server room_id =
-  match Hashtbl.find_opt server.rooms room_id with
+  (* Snapshot the room reference under [server.mutex], then read
+     its peer set under [room.mutex].  Reading [server.rooms]
+     directly without the lock could observe a half-built bucket
+     while a concurrent [get_or_create_room] / [leave_room] is
+     mutating the table. *)
+  let room_opt =
+    Eio.Mutex.use_ro server.mutex (fun () ->
+      Hashtbl.find_opt server.rooms room_id)
+  in
+  match room_opt with
   | None -> []
   | Some room ->
     Eio.Mutex.use_ro room.mutex (fun () ->
       Hashtbl.fold (fun id _ acc -> id :: acc) room.peers [])
+
+(** [room_exists server room_id] reports whether [room_id] is
+    currently tracked.  Useful for tests that need to verify the
+    empty-room cleanup contract without inspecting the internal
+    [server.rooms] Hashtbl directly. *)
+let room_exists server room_id =
+  Eio.Mutex.use_ro server.mutex (fun () ->
+    Hashtbl.mem server.rooms room_id)

--- a/lib/webrtc_signaling.mli
+++ b/lib/webrtc_signaling.mli
@@ -51,9 +51,19 @@ val get_or_create_room : server -> string -> room
 val join_room : server -> room_id:string -> peer_id:string -> unit
 
 (** [leave_room server ~room_id ~peer_id] removes a peer from a room.
-    No-op if the room or peer does not exist. *)
+    No-op if the room or peer does not exist.
+
+    Removes the room itself from [server.rooms] when the last peer
+    leaves, so a stream of unique room ids cannot accumulate empty
+    entries forever. *)
 val leave_room : server -> room_id:string -> peer_id:string -> unit
 
 (** [get_peers server room_id] returns the list of peer IDs in a room.
     Returns an empty list if the room does not exist. *)
 val get_peers : server -> string -> string list
+
+(** [room_exists server room_id] reports whether the server is
+    currently tracking a room with this id.  Contract: an empty
+    room is *not* tracked — once the last peer leaves,
+    [leave_room] collects the entry. *)
+val room_exists : server -> string -> bool

--- a/test/test_webrtc_suite.ml
+++ b/test/test_webrtc_suite.ml
@@ -106,6 +106,55 @@ let test_webrtc_routes () =
   let routes = WR.routes () in
   check int "route count" 2 (List.length routes)
 
+(* Before this PR, [leave_room] never collected the room itself
+   from [server.rooms]; the entry stayed forever even when the
+   last peer disconnected.  A stream of unique [room_id]s — easy
+   to drive from untrusted Join messages — accumulated entries
+   without bound, a slow memory-DoS vector.  Pin the empty-room
+   cleanup contract via the new [room_exists] observer. *)
+
+let test_signaling_room_cleanup_on_last_leave () =
+  let server = WR.Signaling.create_server () in
+  WR.Signaling.join_room server ~room_id:"r1" ~peer_id:"alice";
+  check bool "room exists after join" true (WR.Signaling.room_exists server "r1");
+  WR.Signaling.leave_room server ~room_id:"r1" ~peer_id:"alice";
+  check bool "room collected after last leave"
+    false (WR.Signaling.room_exists server "r1")
+
+let test_signaling_room_stays_with_remaining_peer () =
+  let server = WR.Signaling.create_server () in
+  WR.Signaling.join_room server ~room_id:"r2" ~peer_id:"alice";
+  WR.Signaling.join_room server ~room_id:"r2" ~peer_id:"bob";
+  WR.Signaling.leave_room server ~room_id:"r2" ~peer_id:"alice";
+  check bool "room still alive with remaining peer"
+    true (WR.Signaling.room_exists server "r2");
+  check (list string) "bob remains in peers" ["bob"]
+    (WR.Signaling.get_peers server "r2");
+  (* And once Bob leaves, the room is collected too. *)
+  WR.Signaling.leave_room server ~room_id:"r2" ~peer_id:"bob";
+  check bool "room collected after Bob leaves"
+    false (WR.Signaling.room_exists server "r2")
+
+let test_signaling_leave_unknown_room_is_noop () =
+  (* A leave for a room that never existed must not crash and must
+     not leak a phantom entry. *)
+  let server = WR.Signaling.create_server () in
+  WR.Signaling.leave_room server ~room_id:"never-existed" ~peer_id:"alice";
+  check bool "no phantom room"
+    false (WR.Signaling.room_exists server "never-existed")
+
+let test_signaling_rejoin_after_cleanup () =
+  (* After the room is collected the id must still be usable —
+     [room_exists] tracks current state, not a tombstone. *)
+  let server = WR.Signaling.create_server () in
+  WR.Signaling.join_room server ~room_id:"r3" ~peer_id:"alice";
+  WR.Signaling.leave_room server ~room_id:"r3" ~peer_id:"alice";
+  WR.Signaling.join_room server ~room_id:"r3" ~peer_id:"alice";
+  check bool "rejoin re-creates the room"
+    true (WR.Signaling.room_exists server "r3");
+  check (list string) "alice is back in peers" ["alice"]
+    (WR.Signaling.get_peers server "r3")
+
 let tests = [
   test_case "ice states" `Quick (with_eio test_webrtc_ice_states);
   test_case "peer create" `Quick (with_eio test_webrtc_peer_create);
@@ -118,4 +167,8 @@ let tests = [
   test_case "signaling decode error" `Quick (with_eio test_webrtc_signaling_decode_error);
   test_case "ice candidate" `Quick (with_eio test_webrtc_ice_candidate);
   test_case "routes helper" `Quick (with_eio test_webrtc_routes);
+  test_case "signaling: room cleaned up on last leave" `Quick (with_eio test_signaling_room_cleanup_on_last_leave);
+  test_case "signaling: room kept with remaining peer" `Quick (with_eio test_signaling_room_stays_with_remaining_peer);
+  test_case "signaling: leave unknown room is noop" `Quick (with_eio test_signaling_leave_unknown_room_is_noop);
+  test_case "signaling: rejoin after cleanup" `Quick (with_eio test_signaling_rejoin_after_cleanup);
 ]


### PR DESCRIPTION
## 요약

\`Webrtc_signaling\`의 두 latent 결함 동시 fix (둘 다 \`server.rooms\` 테이블 위).

### 1. server.mutex 없이 lookup → race

\`leave_room\` (line 130-135), \`get_peers\` (line 137-142)이 \`Hashtbl.find_opt server.rooms\`를 *\`server.mutex\` 없이* 호출. \`get_or_create_room\`은 lock 안에서 \`Hashtbl.replace\`로 mutate. 두 fiber가 동시에 join+leave/lookup하면 half-built bucket 관찰 가능 — Eio yield point에서 silent inconsistency.

### 2. Empty room이 영원히 누적 (memory DoS)

\`leave_room\`이 \`room.peers\`에서 peer만 제거하고 \`server.rooms\` 자체 정리 안 함. 임의 \`room_id\`로 join → leave를 반복하면 (untrusted Join message로 자유롭게 driving 가능) \`server.rooms\` Hashtbl이 *영구* 누적. 모든 peer 떠나도 room entry는 남음.

## 변경

**\`lib/webrtc_signaling.ml\`** + **\`lib/webrtc_signaling.mli\`**:

- \`leave_room\` — \`server.mutex\` 안에서 (a) 안전한 room lookup + (b) 마지막 peer가 떠나면 \`Hashtbl.remove server.rooms\`로 entry 회수. lock 순서는 server → room (모듈 안에서 일관 유지, deadlock 불가).
- \`get_peers\` — \`server.mutex\` (RO)로 room 참조 snapshot, 그 후 \`room.mutex\` (RO)로 peer fold.
- \`room_exists : server -> string -> bool\` — 새 observer. server lock 안에서 \`Hashtbl.mem\` 확인. mli 노출이라 caller/test가 cleanup contract를 외부 시그널로 검증 가능.

**\`test/test_webrtc_suite.ml\`** — 4 신규 (WebRTC 그룹, 15 total):

- \`room cleaned up on last leave\` — join → leave → \`room_exists = false\`.
- \`room kept with remaining peer\` — 두 peer join 후 한 명 leave → room 살아있음 + 남은 peer 1명. 두 번째 leave 후 \`room_exists = false\`.
- \`leave unknown room is noop\` — 존재 안 한 room_id로 leave 호출 → 안 crash + phantom entry 안 생김.
- \`rejoin after cleanup\` — leave 후 같은 id로 다시 join 가능 → \`room_exists\`는 tombstone이 아니라 current state.

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **232 tests pass** (기존 228 + 신규 4).
- WebRTC 그룹 15/15 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 race와 memory leak을 *닫음*.
- ❌ string 분류기 아님.
- ❌ N-of-M 아님 — \`leave_room\`/\`get_peers\` 두 race site를 같은 PR에서 동일 lock 패턴으로 fix.
- ❌ catch-all/cap 안티패턴 아님.

## RFC

\`RFC-WAIVED: signaling server 정확성/리소스 fix. 외부 API는 \`room_exists\` 추가 노출 (backwards compatible — 기존 함수 시그니처/시멘틱 변경 없음, 단 \`leave_room\` 시 empty room 자동 회수 contract 추가).\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>