### PR TITLE
fix(backpressure): Drop_newest no longer spins; reject invalid capacity

### DIFF
--- a/lib/backpressure.ml
+++ b/lib/backpressure.ml
@@ -61,16 +61,28 @@ module Buffer = struct
     not_empty : Eio.Condition.t;
   }
 
-  (** Create a bounded buffer *)
-  let create ?(capacity = 1000) ?(strategy = Block) () = {
-    items = [];
-    size = 0;
-    capacity;
-    strategy;
-    mutex = Eio.Mutex.create ();
-    not_full = Eio.Condition.create ();
-    not_empty = Eio.Condition.create ();
-  }
+  (** Create a bounded buffer.
+
+      [capacity] must be strictly positive — with [capacity <= 0]
+      the buffer is always full and the [Block] strategy turns
+      [push] into a permanent deadlock against a producer that has
+      no matching consumer.  Reject at construction rather than
+      letting the misconfiguration silently freeze a fiber. *)
+  let create ?(capacity = 1000) ?(strategy = Block) () =
+    if capacity <= 0 then
+      invalid_arg
+        (Printf.sprintf
+           "Backpressure.Buffer.create: capacity must be > 0 (got %d)"
+           capacity);
+    {
+      items = [];
+      size = 0;
+      capacity;
+      strategy;
+      mutex = Eio.Mutex.create ();
+      not_full = Eio.Condition.create ();
+      not_empty = Eio.Condition.create ();
+    }
 
   (** Check if buffer is full *)
   let is_full t = t.size >= t.capacity
@@ -81,30 +93,46 @@ module Buffer = struct
   (** Current buffer size *)
   let length t = t.size
 
-  (** Push item to buffer (may block or drop based on strategy) *)
+  (** Push item to buffer (may block or drop based on strategy).
+
+      Before this PR, [Drop_newest]'s loop body was [()] — a no-op
+      inside [while is_full t].  The loop condition stayed true
+      forever and the fiber went into an unbounded CPU spin.
+      [Drop_newest] was thus a fatal silent bug: any caller that
+      picked it pinned a worker the moment the buffer hit capacity.
+
+      The new control flow tracks two booleans:
+      - [should_insert] — false only on [Drop_newest], skipping the
+        post-loop insert
+      - [keep_waiting] — drives the wait/drop loop; explicitly
+        cleared by [Drop_newest] so we always make progress
+
+      [Drop_oldest] re-evaluates [is_full] after a successful drop;
+      with [capacity > 0] (enforced at construction) a single drop
+      is enough, but the re-check keeps the invariant local. *)
   let push t item =
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
-      (* Handle full buffer based on strategy *)
-      while is_full t do
+      let should_insert = ref true in
+      let keep_waiting = ref (is_full t) in
+      while !keep_waiting do
         match t.strategy with
         | Block ->
-          Eio.Condition.await t.not_full t.mutex
+          Eio.Condition.await t.not_full t.mutex;
+          keep_waiting := is_full t
         | Drop_oldest ->
-          (* Remove oldest (last in reversed list) *)
           (match List.rev t.items with
            | [] -> ()
            | _ :: rest ->
              t.items <- List.rev rest;
-             t.size <- t.size - 1)
+             t.size <- t.size - 1);
+          keep_waiting := is_full t
         | Drop_newest ->
-          (* Just don't add the new item *)
-          ()
+          should_insert := false;
+          keep_waiting := false
         | Error ->
           raise Buffer_overflow
       done;
-
-      (* Add item if not using Drop_newest when full *)
-      if not (is_full t && t.strategy = Drop_newest) then begin
+      if !should_insert then begin
         t.items <- item :: t.items;
         t.size <- t.size + 1;
         Eio.Condition.broadcast t.not_empty

--- a/test/test_backpressure_suite.ml
+++ b/test/test_backpressure_suite.ml
@@ -105,11 +105,55 @@ let test_window_update_size () =
   BP.Window.update_size win 1000;
   check int "capped at max" 500 (BP.Window.current_size win)
 
+(* Before this PR, [Drop_newest] inside [Buffer.push] was a fatal
+   silent bug: the strategy's loop body was [()] inside
+   [while is_full t], so once the buffer hit capacity the fiber
+   spun the CPU forever — the strategy "drop the incoming item if
+   the buffer is full" was effectively unimplemented. *)
+
+let test_buffer_drop_newest_does_not_spin () =
+  let buf = BP.Buffer.create ~capacity:2 ~strategy:Drop_newest () in
+  BP.Buffer.push buf 1;
+  BP.Buffer.push buf 2;
+  (* Buffer at capacity.  These calls would spin forever before
+     this PR; if the test returns at all, the push loop
+     terminates. *)
+  BP.Buffer.push buf 3;
+  BP.Buffer.push buf 4;
+  check int "size capped at capacity" 2 (BP.Buffer.length buf);
+  (* The retained items are the original two in FIFO order; the
+     newer ones must have been dropped. *)
+  check int "first stays" 1 (BP.Buffer.pop buf);
+  check int "second stays" 2 (BP.Buffer.pop buf);
+  check int "buffer drained" 0 (BP.Buffer.length buf)
+
+let test_buffer_drop_newest_room_after_pop () =
+  (* Once the consumer drains an item the producer can refill the
+     slot — Drop_newest is a per-push decision, not a permanent
+     "buffer closed" state. *)
+  let buf = BP.Buffer.create ~capacity:1 ~strategy:Drop_newest () in
+  BP.Buffer.push buf 1;
+  BP.Buffer.push buf 2;  (* dropped *)
+  check int "first kept" 1 (BP.Buffer.pop buf);
+  BP.Buffer.push buf 3;  (* room is back *)
+  check int "third kept after drain" 3 (BP.Buffer.pop buf)
+
+let test_buffer_capacity_zero_rejected () =
+  check_raises "capacity 0"
+    (Invalid_argument "Backpressure.Buffer.create: capacity must be > 0 (got 0)")
+    (fun () -> ignore (BP.Buffer.create ~capacity:0 ()));
+  check_raises "capacity -1"
+    (Invalid_argument "Backpressure.Buffer.create: capacity must be > 0 (got -1)")
+    (fun () -> ignore (BP.Buffer.create ~capacity:(-1) ()))
+
 let tests = [
   test_case "buffer create" `Quick (with_eio test_buffer_create);
   test_case "buffer push pop" `Quick (with_eio test_buffer_push_pop);
   test_case "buffer try_pop" `Quick (with_eio test_buffer_try_pop);
   test_case "buffer drop oldest" `Quick (with_eio test_buffer_drop_oldest);
+  test_case "buffer drop newest terminates" `Quick (with_eio test_buffer_drop_newest_does_not_spin);
+  test_case "buffer drop newest room after pop" `Quick (with_eio test_buffer_drop_newest_room_after_pop);
+  test_case "buffer capacity <= 0 rejected" `Quick (with_eio test_buffer_capacity_zero_rejected);
   test_case "channel create" `Quick (with_eio test_channel_create);
   test_case "channel send recv" `Quick (with_eio test_channel_send_recv);
   test_case "channel close" `Quick (with_eio test_channel_close);


### PR DESCRIPTION
## 요약

\`Buffer.push\`의 \`Drop_newest\` strategy가 fatal silent bug. \`while is_full t do ... | Drop_newest -> ()\` 가 no-op이라 loop 조건이 영원히 true → 무한 CPU spin. \"buffer가 full이면 새 item을 drop\"이라는 strategy의 의미가 *완전히 미구현*. 그 strategy를 선택한 caller의 fiber는 worker pool을 무한 점유 (iter 56의 dead-config 패턴의 더 극단적 버전 — config가 *살아있지만 동작 자체가 spin*).

부가 발견: \`create ~capacity:0\` (또는 음수)은 \`is_full\`을 영구 true로 만들어 \`Block\` strategy를 *영구 deadlock*. silent misconfig.

## 변경

**\`lib/backpressure.ml\`** — \`Buffer.push\` 재구성:

- 두 boolean state로 wait loop 제어: \`should_insert\` (Drop_newest에서 false), \`keep_waiting\` (Drop_newest에서 false로 즉시 종료).
- \`Drop_oldest\`는 한 번 drop 후 \`is_full t\` 재평가 (capacity > 0이라 한 drop이면 충분하지만 invariant 명시).
- \`Block\`은 await 후 동일하게 재평가.
- \`Error\`는 그대로 raise.

\`Buffer.create\`에 \`capacity <= 0\` reject 추가 (\`Invalid_argument\` + 정확한 진단 메시지).

**\`test/test_backpressure_suite.ml\`** — 3 신규 (Backpressure 그룹, 15 total):

- **\`buffer drop newest terminates\`** — capacity:2 buffer에 4번 push. 4번이 *반환됨* (spin 없음) + 유지된 항목은 FIFO로 1, 2.
- **\`buffer drop newest room after pop\`** — pop으로 slot 회복 후 다음 push가 채택 (drop은 per-call 결정, 영구 close 아님).
- **\`buffer capacity <= 0 rejected\`** — \`create ~capacity:0\` / \`-1\` → \`Invalid_argument\` 정확한 메시지.

PR 이전엔 \`terminates\` test가 \`test_kirin.exe\` 전체를 무한 정지시켰을 것 — 현재 전체 suite 0.26s 완료로 spin 제거 직접 입증.

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **231 tests pass** (기존 228 + 신규 3). 0.26s 완료.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 무한 spin / silent deadlock을 *닫음*.
- ❌ string 분류기 아님 — variant strategy 위에 explicit branch + boolean state.
- ❌ N-of-M 아님 — \`Buffer.push\` 단일 callsite + \`create\` boundary 검증 같이.
- ❌ catch-all / cap 안티패턴 아님.

## RFC

\`RFC-WAIVED: data plane 정확성 fix (silent infinite spin 차단). 외부 API contract는 \`create\`가 \`capacity <= 0\`에서 raise하는 것 (이전엔 silent broken). backwards compatible — 정상 capacity 호출은 무영향.\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>