### PR TITLE
fix(compress): honour q=0 reject and case-insensitive coding names

### DIFF
--- a/lib/compress.ml
+++ b/lib/compress.ml
@@ -5,14 +5,55 @@ type algorithm =
   | Gzip
   | Deflate
 
-(** Parse Accept-Encoding header and return preferred algorithm *)
+(* RFC 7231 §3.1.2.1 + §5.3.4: an Accept-Encoding token is a
+   coding name plus optional parameters, the most common of which
+   is [q=<float>].  Two contracts the old [List.mem]-based parser
+   silently broke:
+
+   - codings are case-insensitive ([GZIP] is the same as [gzip])
+   - [q=0] is an explicit *reject*, not a no-op — the client is
+     saying "I cannot or will not accept this encoding"
+
+   The old code therefore (a) refused to compress for clients
+   that capitalised their header (browsers don't, but proxies and
+   custom HTTP clients sometimes do), and (b) compressed *anyway*
+   for clients that explicitly opted out via [q=0].  The latter
+   is the more concerning surface: a client running in a
+   CRIME/BREACH-aware environment may set
+   [Accept-Encoding: gzip;q=0] precisely to disable compression,
+   and the server has to honour that. *)
+let parse_encoding_token raw =
+  match String.split_on_char ';' raw with
+  | [] -> None
+  | name :: params ->
+    let name = String.trim name |> String.lowercase_ascii in
+    if name = "" then None
+    else
+      let q =
+        List.fold_left (fun acc param ->
+          match String.split_on_char '=' (String.trim param) with
+          | [k; v] when String.lowercase_ascii (String.trim k) = "q" ->
+            (match float_of_string_opt (String.trim v) with
+             | Some f -> f
+             | None -> acc)
+          | _ -> acc
+        ) 1.0 params
+      in
+      Some (name, q)
+
+(** Parse Accept-Encoding header and return the preferred algorithm
+    that the client *accepts* with [q > 0].  Priority gzip > deflate
+    matches the pre-PR ordering. *)
 let parse_accept_encoding header_value =
-  (* Accept-Encoding: gzip, deflate, br *)
-  let encodings = String.split_on_char ',' header_value in
-  let encodings = List.map String.trim encodings in
-  (* Priority: gzip > deflate *)
-  if List.mem "gzip" encodings then Some Gzip
-  else if List.mem "deflate" encodings then Some Deflate
+  let tokens =
+    String.split_on_char ',' header_value
+    |> List.filter_map parse_encoding_token
+  in
+  let accepts name =
+    List.exists (fun (n, q) -> n = name && q > 0.0) tokens
+  in
+  if accepts "gzip" then Some Gzip
+  else if accepts "deflate" then Some Deflate
   else None
 
 (** Content types that should not be compressed *)

--- a/test/test_compress_suite.ml
+++ b/test/test_compress_suite.ml
@@ -56,10 +56,86 @@ let test_compress_middleware () =
   check (option string) "content-encoding" (Some "gzip") (Kirin.Response.header "content-encoding" resp);
   check bool "response compressed" true (String.length (response_body_to_string (Kirin.Response.body resp)) < 2000)
 
+(* Pretty-printer for the algorithm option so the new RFC tests
+   can use the existing [check (option ...)] shape without
+   re-declaring the testable inline at every callsite. *)
+let algo_testable =
+  Alcotest.testable
+    (fun fmt -> function
+       | Kirin.Compress.Gzip -> Format.fprintf fmt "Gzip"
+       | Kirin.Compress.Deflate -> Format.fprintf fmt "Deflate")
+    (=)
+
+(* RFC 7231 §3.1.2.1: coding names are case-insensitive.  Browsers
+   send lowercase but proxies and custom HTTP clients occasionally
+   send uppercase; before this PR an uppercase coding silently
+   disabled compression even though the client clearly accepted
+   it. *)
+let test_accept_encoding_is_case_insensitive () =
+  check (option algo_testable) "GZIP upper"
+    (Some Kirin.Compress.Gzip)
+    (Kirin.Compress.parse_accept_encoding "GZIP, br");
+  check (option algo_testable) "Gzip mixed"
+    (Some Kirin.Compress.Gzip)
+    (Kirin.Compress.parse_accept_encoding "Gzip");
+  check (option algo_testable) "DEFLATE upper"
+    (Some Kirin.Compress.Deflate)
+    (Kirin.Compress.parse_accept_encoding "DEFLATE")
+
+(* RFC 7231 §5.3.4: [q=0] is an explicit reject.  Before this PR
+   the server cheerfully compressed for clients that had opted
+   out — a real concern for CRIME/BREACH-aware clients that set
+   [Accept-Encoding: gzip;q=0] deliberately. *)
+let test_accept_encoding_q_zero_is_reject () =
+  check (option algo_testable) "gzip rejected, no alternative"
+    None
+    (Kirin.Compress.parse_accept_encoding "gzip;q=0");
+  check (option algo_testable) "gzip rejected, deflate accepted"
+    (Some Kirin.Compress.Deflate)
+    (Kirin.Compress.parse_accept_encoding "gzip;q=0, deflate");
+  check (option algo_testable) "both rejected"
+    None
+    (Kirin.Compress.parse_accept_encoding "gzip;q=0, deflate;q=0");
+  check (option algo_testable) "uppercase Q=0 still rejects"
+    None
+    (Kirin.Compress.parse_accept_encoding "gzip;Q=0")
+
+(* Sanity: q > 0 accepts; gzip > deflate priority preserved. *)
+let test_accept_encoding_q_positive_accepts () =
+  check (option algo_testable) "gzip q=0.5 accepted"
+    (Some Kirin.Compress.Gzip)
+    (Kirin.Compress.parse_accept_encoding "gzip;q=0.5");
+  check (option algo_testable) "gzip wins over deflate"
+    (Some Kirin.Compress.Gzip)
+    (Kirin.Compress.parse_accept_encoding "deflate;q=1.0, gzip;q=0.5")
+
+let test_accept_encoding_whitespace_tolerance () =
+  (* Real proxies sometimes pad with arbitrary spacing around
+     ';' and '='; the parser must still see the q-value. *)
+  check (option algo_testable) "spaces around ; and ="
+    None
+    (Kirin.Compress.parse_accept_encoding "gzip ; q = 0");
+  check (option algo_testable) "spaces around comma"
+    (Some Kirin.Compress.Gzip)
+    (Kirin.Compress.parse_accept_encoding "  gzip  ,  deflate  ")
+
+let test_accept_encoding_garbage_q_is_ignored () =
+  (* A malformed q-value should be treated as if absent (default
+     1.0), not as a reject.  Pin "garbage means accept" rather
+     than "garbage means reject". *)
+  check (option algo_testable) "garbage q-value defaults to accept"
+    (Some Kirin.Compress.Gzip)
+    (Kirin.Compress.parse_accept_encoding "gzip;q=banana")
+
 let tests = [
   test_case "parse accept-encoding" `Quick test_compress_parse_accept_encoding;
   test_case "skip compression for" `Quick test_compress_skip_for_images;
   test_case "gzip compression" `Quick test_compress_gzip;
   test_case "deflate compression" `Quick test_compress_deflate;
   test_case "compression middleware" `Quick test_compress_middleware;
+  test_case "accept-encoding case insensitive" `Quick test_accept_encoding_is_case_insensitive;
+  test_case "accept-encoding q=0 is reject" `Quick test_accept_encoding_q_zero_is_reject;
+  test_case "accept-encoding q>0 accepts" `Quick test_accept_encoding_q_positive_accepts;
+  test_case "accept-encoding whitespace tolerance" `Quick test_accept_encoding_whitespace_tolerance;
+  test_case "accept-encoding garbage q ignored" `Quick test_accept_encoding_garbage_q_is_ignored;
 ]


### PR DESCRIPTION
## 요약

\`Compress.parse_accept_encoding\`이 두 RFC 7231 contract를 silent하게 위반하고 있었음.

### 1. \`q=0\` reject 무시 (§5.3.4) — security relevant

\`Accept-Encoding: gzip;q=0\`은 \"이 encoding을 받지 *못한다*\"는 explicit reject. 그러나 \`List.mem \"gzip\"\` 매치 → 그래도 gzip 압축 → 클라이언트 깨짐. **CRIME / BREACH 방어 시나리오**: compression side-channel을 피하려고 \`q=0\`을 의도적으로 보내는 클라이언트가 있는데 server가 그 의도를 무시하고 압축하면 side-channel attack surface가 reopen.

### 2. Case-insensitive 위반 (§3.1.2.1)

\`Accept-Encoding: GZIP\` 등 uppercase coding은 RFC 상 \`gzip\`과 동등하지만 \`List.mem\`이 byte-exact라 거부. 일부 proxy / custom HTTP client에서 발생.

## 변경

**\`lib/compress.ml\`** — \`parse_accept_encoding\` 재작성:

- 새 헬퍼 \`parse_encoding_token\`이 \`;\`로 토큰 split, name을 \`String.trim + String.lowercase_ascii\`로 정규화, \`q=<float>\` 파라미터 읽음 (key도 case-insensitive 비교).
- 메인 함수가 \`accepts name = ∃ token. token.name = name ∧ token.q > 0.0\` 필터로 검사. gzip > deflate priority 유지.
- 잘못된 q-value (\`q=banana\`)는 spec default 1.0 fallback (\"garbage means accept\").

**\`test/test_compress_suite.ml\`** — 5 신규 (Compress 그룹, 10 total):

- **case insensitive**: \`GZIP\` / \`Gzip\` / \`DEFLATE\` 모두 매치.
- **q=0 reject**: alone (None) / deflate와 함께 (Some Deflate) / 모두 reject (None) / uppercase Q (None).
- **q>0 accepts**: \`gzip;q=0.5\` 통과, gzip > deflate priority 유지.
- **whitespace tolerance**: \`;\`/\`=\`/\`,\` 주위 임의 공백.
- **garbage q ignored**: \`q=banana\` → spec default 1.0 → accept.

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **233 tests pass** (기존 228 + 신규 5).
- Compress 그룹 10/10 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 RFC 위반과 CRIME/BREACH 회피 차단 surface를 *닫음*.
- ❌ string 분류기 아님 — typed 파싱 (token → (name, q)), \`accepts\` predicate는 typed list 위에서 동작.
- ❌ N-of-M 아님 — \`parse_accept_encoding\` 단일 함수 + 헬퍼 추출.
- ❌ catch-all/cap 안티패턴 아님.

## RFC

\`RFC-WAIVED: HTTP RFC 7231 compliance fix. 외부 API contract 변경 없음 (\`parse_accept_encoding\`의 시그니처와 priority(gzip > deflate)는 동일, q=0/대소문자 처리만 정확해짐).\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>