### PR TITLE
fix(ratelimit): require explicit opt-in to trust forwarded headers

### DIFF
--- a/lib/ratelimit.ml
+++ b/lib/ratelimit.ml
@@ -57,19 +57,45 @@ module Store = struct
       List.iter (Hashtbl.remove buckets) !to_remove)
 end
 
-(** Get client identifier from request (IP address) *)
-let get_client_id req =
-  (* Try X-Forwarded-For first, then X-Real-IP, then connection IP *)
-  match Request.header "x-forwarded-for" req with
-  | Some xff ->
-    (* Take first IP from X-Forwarded-For *)
-    (match String.split_on_char ',' xff with
-    | ip :: _ -> String.trim ip
-    | [] -> "unknown")
-  | None ->
-    match Request.header "x-real-ip" req with
-    | Some ip -> ip
-    | None -> "unknown"
+(* X-Forwarded-For / X-Real-IP can be set by *any* HTTP client, so
+   trusting them unconditionally turns the rate limiter into a
+   sieve: a request that sends
+   [X-Forwarded-For: <random ip>] each time burns through unique
+   buckets and bypasses the limit entirely.  Worse, a request that
+   sends [X-Forwarded-For: <victim>] drains the victim's bucket
+   instead of its own — targeted lockout.
+
+   These headers are only safe when the request arrived through a
+   trusted reverse proxy that overwrites them; the application has
+   to opt in to that contract.  Default to [false]: ignore the
+   forwarded headers entirely and fall back to ["unknown"].
+   Deployments that *do* sit behind a known proxy (nginx, ALB,
+   Cloudflare) can pass [~trust_forwarded:true]. *)
+let trim_first_csv s =
+  match String.split_on_char ',' s with
+  | [] -> ""
+  | first :: _ -> String.trim first
+
+(** [get_client_id ?trust_forwarded req] extracts a client
+    identifier from the request.
+
+    When [trust_forwarded] is [false] (the default) the forwarded
+    headers are ignored — they are caller-controlled and forging
+    them is the rate-limit bypass surface.  When [true], the first
+    address in [X-Forwarded-For] is used, falling back to
+    [X-Real-IP].  Only enable [trust_forwarded] behind a reverse
+    proxy that rewrites those headers itself. *)
+let get_client_id ?(trust_forwarded = false) req =
+  if not trust_forwarded then "unknown"
+  else
+    match Request.header "x-forwarded-for" req with
+    | Some xff when xff <> "" ->
+      let ip = trim_first_csv xff in
+      if ip = "" then "unknown" else ip
+    | _ ->
+      match Request.header "x-real-ip" req with
+      | Some ip when ip <> "" -> ip
+      | _ -> "unknown"
 
 (** Check if request is allowed and consume a token.
     The entire read-modify-write is performed under Store.mu so that
@@ -124,8 +150,14 @@ let limit_exceeded_response ~retry_after ~limit =
   |> Response.with_header "x-ratelimit-limit" (string_of_int limit)
   |> Response.with_header "x-ratelimit-remaining" "0"
 
+(* Monomorphic wrapper so [middleware]'s [?get_key] signature
+   stays [Request.t -> string] — exposing the [?trust_forwarded]
+   default through the middleware would change its callable type
+   and break callers that already pass [~get_key]. *)
+let default_get_key req = get_client_id req
+
 (** Rate limiting middleware *)
-let middleware ?(config = default_config) ?(get_key = get_client_id) : (Request.t -> Response.t) -> (Request.t -> Response.t) =
+let middleware ?(config = default_config) ?(get_key = default_get_key) : (Request.t -> Response.t) -> (Request.t -> Response.t) =
   fun handler req ->
     let client_id = get_key req in
     match check_rate_limit config client_id with
@@ -142,7 +174,7 @@ module type Storage = sig
 end
 
 (** Advanced: Create middleware with custom storage *)
-let middleware_with_storage (module S : Storage) ?(config = default_config) ?(get_key = get_client_id) =
+let middleware_with_storage (module S : Storage) ?(config = default_config) ?(get_key = default_get_key) =
   fun handler req ->
     let client_id = get_key req in
     let now = Unix.gettimeofday () in

--- a/lib/ratelimit.mli
+++ b/lib/ratelimit.mli
@@ -56,9 +56,22 @@ end
 
 (** {1 Client Identification} *)
 
-(** [get_client_id req] extracts a client identifier from the request.
-    Checks X-Forwarded-For, then X-Real-IP, then falls back to ["unknown"]. *)
-val get_client_id : Request.t -> string
+(** [get_client_id ?trust_forwarded req] extracts a client
+    identifier from the request.
+
+    When [trust_forwarded] is [false] (the default) the
+    [X-Forwarded-For] / [X-Real-IP] headers are *ignored* and
+    ["unknown"] is returned.  Those headers are caller-controlled,
+    so trusting them unconditionally lets any client bypass the
+    limit (send a random IP per request) or burn a victim's
+    bucket (send the victim's IP) — both observed bypass surfaces
+    on rate-limited APIs.
+
+    Set [trust_forwarded:true] only behind a reverse proxy (nginx,
+    ALB, Cloudflare) that rewrites those headers from the actual
+    socket peer.  In that mode the first comma-separated address in
+    [X-Forwarded-For] is used, falling back to [X-Real-IP]. *)
+val get_client_id : ?trust_forwarded:bool -> Request.t -> string
 
 (** {1 Rate Checking} *)
 

--- a/test/test_ratelimit_suite.ml
+++ b/test/test_ratelimit_suite.ml
@@ -54,8 +54,115 @@ let test_ratelimit_middleware_limits () =
 
 let with_eio_rl f () = Eio_main.run @@ fun _env -> f ()
 
+(* X-Forwarded-For trust regression tests.
+
+   Before this PR, [get_client_id req] returned the first
+   comma-segment of X-Forwarded-For, which let any HTTP client
+   pick its own rate-limit bucket key by editing a request header.
+   Two concrete bypasses fell out of that:
+
+   - rotate the XFF value per request → infinite unique buckets,
+     no limit ever fires
+   - send a victim's IP as XFF → drain the victim's bucket
+     (targeted lockout)
+
+   New contract: XFF is ignored unless the caller explicitly opts
+   in with [~trust_forwarded:true], which they should only do
+   behind a reverse proxy that rewrites the header.  Tests pin
+   both halves. *)
+
+let test_get_client_id_ignores_xff_by_default () =
+  let req =
+    make_test_request
+      ~headers:[("x-forwarded-for", "1.2.3.4")]
+      "/"
+  in
+  check string "XFF ignored by default" "unknown"
+    (Kirin.Ratelimit.get_client_id req)
+
+let test_get_client_id_ignores_real_ip_by_default () =
+  let req =
+    make_test_request
+      ~headers:[("x-real-ip", "1.2.3.4")]
+      "/"
+  in
+  check string "X-Real-IP ignored by default" "unknown"
+    (Kirin.Ratelimit.get_client_id req)
+
+let test_get_client_id_uses_xff_when_trusted () =
+  let req =
+    make_test_request
+      ~headers:[("x-forwarded-for", "203.0.113.7, 10.0.0.1")]
+      "/"
+  in
+  check string "first XFF segment used when trusted"
+    "203.0.113.7"
+    (Kirin.Ratelimit.get_client_id ~trust_forwarded:true req)
+
+let test_get_client_id_falls_back_to_real_ip_when_trusted () =
+  let req =
+    make_test_request
+      ~headers:[("x-real-ip", "198.51.100.42")]
+      "/"
+  in
+  check string "X-Real-IP used when XFF absent and trust enabled"
+    "198.51.100.42"
+    (Kirin.Ratelimit.get_client_id ~trust_forwarded:true req)
+
+let test_get_client_id_empty_xff_falls_back_to_unknown () =
+  (* Some proxies emit an empty XFF on internal calls; that must
+     not bind every such request to the "" bucket. *)
+  let req =
+    make_test_request
+      ~headers:[("x-forwarded-for", "")]
+      "/"
+  in
+  check string "empty XFF -> unknown"
+    "unknown"
+    (Kirin.Ratelimit.get_client_id ~trust_forwarded:true req);
+  let req2 =
+    make_test_request
+      ~headers:[("x-forwarded-for", ",")]
+      "/"
+  in
+  check string "comma-only XFF -> unknown"
+    "unknown"
+    (Kirin.Ratelimit.get_client_id ~trust_forwarded:true req2)
+
+let test_xff_rotation_does_not_bypass_default () =
+  (* The bypass scenario: a malicious client sends a fresh XFF on
+     every request hoping to be assigned a fresh bucket.  In the
+     secure default mode every such request maps to "unknown" and
+     therefore shares one bucket — the limit fires on the third
+     hit. *)
+  let config : Kirin.rate_limit_config = {
+    requests_per_second = 0.001;  (* effectively no refill during test *)
+    burst_size = 2;
+  } in
+  let handler _req = Kirin.text "OK" in
+  let with_limit = Kirin.rate_limit ~config handler in
+  let make_req xff =
+    make_test_request
+      ~headers:[("x-forwarded-for", xff)]
+      ~meth:`GET
+      "/"
+  in
+  let r1 = with_limit (make_req "10.0.0.1") in
+  let r2 = with_limit (make_req "10.0.0.2") in
+  let r3 = with_limit (make_req "10.0.0.3") in
+  check int "first burst slot" 200 (Kirin.Response.status_code r1);
+  check int "second burst slot" 200 (Kirin.Response.status_code r2);
+  check int "third request limited despite XFF rotation"
+    429 (Kirin.Response.status_code r3)
+
 let tests = [
   test_case "default config" `Quick test_ratelimit_default_config;
   test_case "middleware allows" `Quick (with_eio_rl test_ratelimit_middleware_allows);
   test_case "middleware limits" `Quick (with_eio_rl test_ratelimit_middleware_limits);
+  test_case "XFF ignored by default" `Quick test_get_client_id_ignores_xff_by_default;
+  test_case "X-Real-IP ignored by default" `Quick test_get_client_id_ignores_real_ip_by_default;
+  test_case "XFF used when trusted" `Quick test_get_client_id_uses_xff_when_trusted;
+  test_case "X-Real-IP fallback when trusted" `Quick test_get_client_id_falls_back_to_real_ip_when_trusted;
+  test_case "empty XFF falls back" `Quick test_get_client_id_empty_xff_falls_back_to_unknown;
+  test_case "XFF rotation cannot bypass default" `Quick (with_eio_rl test_xff_rotation_does_not_bypass_default);
 ]


### PR DESCRIPTION
## 요약 (BREAKING: secure default 회복)

\`Ratelimit.get_client_id\`이 \`X-Forwarded-For\` / \`X-Real-IP\` 헤더를 **무조건** 신뢰. 두 헤더 모두 *attacker-controlled* 요청 헤더라 rate limiter 우회 surface:

1. **Bypass**: client가 매 요청마다 임의의 \`X-Forwarded-For: <random IP>\`를 보내면 → 매번 새 bucket → rate limit 완전 우회.
2. **Targeted lockout**: client가 \`X-Forwarded-For: <victim IP>\`를 보내면 → *victim의 bucket을 소진* → victim이 자기 IP로 접속 시 429.

Rate-limited API의 well-known bypass 패턴.

## 변경

**\`lib/ratelimit.ml\`** + **\`lib/ratelimit.mli\`**:

- \`get_client_id\`의 시그니처가 \`?trust_forwarded:bool -> Request.t -> string\`. **default false** — XFF/X-Real-IP 무시하고 \`\"unknown\"\` 반환.
- \`trust_forwarded:true\` 시에만 XFF 첫 comma-segment 사용, fallback to X-Real-IP. 빈 XFF (\`\"\"\` 또는 \`\",\"\`)는 \`\"unknown\"\`으로 안전 fallback (proxy가 빈 XFF 보내는 internal call에서 empty-string bucket 공유 방지).
- \`middleware\`의 default \`get_key\`는 monomorphic wrapper \`default_get_key req = get_client_id req\` — \`?trust_forwarded\`가 \`middleware\` 시그니처로 leak되어 caller 깨지는 것 방지.

**Backwards compatibility**: \`get_client_id\`을 직접 호출하는 caller는 secure-default 영향 받음. XFF에 의존하는 deployments는 \`~trust_forwarded:true\`로 opt-in 필요. 명시적 \`~get_key:custom_fn\` 전달 caller는 영향 없음.

**\`test/test_ratelimit_suite.ml\`** — 6 신규 (RateLimit 그룹, 9 total):

- **\`XFF ignored by default\`** / **\`X-Real-IP ignored by default\`** — secure default 핀.
- **\`XFF used when trusted\`** — multi-hop XFF (\`203.0.113.7, 10.0.0.1\`)에서 첫 segment 채택.
- **\`X-Real-IP fallback when trusted\`** — XFF 없을 때 X-Real-IP fallback.
- **\`empty XFF falls back\`** — \`\"\"\` / \`\",\"\` 둘 다 \`\"unknown\"\`.
- **\`XFF rotation cannot bypass default\`** — end-to-end: 3 requests × 3 distinct XFF + burst=2 → 200/200/429. PR 이전엔 모두 200.

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **234 tests pass** (기존 228 + 신규 6).
- RateLimit 그룹 9/9 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — bypass surface를 *닫음*.
- ❌ string 분류기 아님 — boolean opt-in.
- ❌ N-of-M 아님 — 단일 진입점 \`get_client_id\`.
- ❌ catch-all/cap 안티패턴 아님.

## RFC

\`RFC-WAIVED: rate-limit bypass surface fix. secure-default 회복. 외부 API에 \`?trust_forwarded\` 옵션 추가 (breaking - XFF 의존 caller는 opt-in 필요), 명시적으로 PR body에 BREAKING 표기.\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>