### PR TITLE
fix(sse): reject CR/LF in event/id fields; split data on CR + CRLF

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -30,16 +30,82 @@ let with_id id e = { e with id = Some id }
 (** Add retry interval to SSE event *)
 let with_retry ms e = { e with retry = Some ms }
 
+(* SSE wire format is line-oriented: each field occupies one line
+   and a blank line terminates the event.  The HTML living
+   standard treats CR, LF, *and* CRLF as line breaks
+   (whatwg.org/html§server-sent-events).
+
+   Two surfaces matter at encode time:
+
+   1. The [event] and [id] fields MUST stay on a single line.  If
+      a caller smuggles a [\n] or [\r] inside either, the encoded
+      output gets extra rows the receiver reads as legitimate
+      additional SSE fields — SSE-protocol injection.  Reject
+      those bytes here rather than silently writing a malformed
+      (attacker-shaped) stream.
+
+   2. The [data] field is intentionally multi-line, but the old
+      splitter only recognised [\n].  A standalone [\r] therefore
+      escaped into the wire and the receiver would interpret it
+      as a line break anyway — same injection by a different
+      route.  Split on CR / LF / CRLF so what we emit matches the
+      spec's parsing rules. *)
+
+let contains_cr_or_lf s =
+  let bad = ref false in
+  String.iter (fun c -> if c = '\r' || c = '\n' then bad := true) s;
+  !bad
+
+let validate_single_line ~field s =
+  if contains_cr_or_lf s then
+    invalid_arg
+      (Printf.sprintf
+         "Sse.encode: %s field contains CR/LF; SSE protocol injection rejected"
+         field)
+
+(* Split a string on any of CR, LF, CRLF.  Empty input yields one
+   empty segment, matching [String.split_on_char] semantics so the
+   prior "empty data still emits a single [data: ] line" behaviour
+   is preserved. *)
+let split_sse_lines s =
+  let buf = Buffer.create (String.length s) in
+  let acc = ref [] in
+  let flush () = acc := Buffer.contents buf :: !acc; Buffer.clear buf in
+  let n = String.length s in
+  let i = ref 0 in
+  while !i < n do
+    let c = s.[!i] in
+    if c = '\r' then begin
+      flush ();
+      (* CRLF is one break, not two. *)
+      if !i + 1 < n && s.[!i + 1] = '\n' then incr i;
+      incr i
+    end else if c = '\n' then begin
+      flush ();
+      incr i
+    end else begin
+      Buffer.add_char buf c;
+      incr i
+    end
+  done;
+  flush ();
+  List.rev !acc
+
 (** Encode SSE event to string.
-    Field order: event, data, id, retry (common convention, matches MDN examples) *)
+    Field order: event, data, id, retry (common convention, matches MDN examples).
+
+    Raises [Invalid_argument] when [event] or [id] contain CR/LF —
+    SSE protocol injection guard. *)
 let encode e =
+  Option.iter (validate_single_line ~field:"event") e.event;
+  Option.iter (validate_single_line ~field:"id") e.id;
   let buf = Buffer.create 64 in
   (* 1. event type *)
   (match e.event with
    | Some t -> Buffer.add_string buf ("event: " ^ t ^ "\n")
    | None -> ());
-  (* 2. data (handles multi-line) *)
-  String.split_on_char '\n' e.data
+  (* 2. data (CR/LF/CRLF all break lines) *)
+  split_sse_lines e.data
   |> List.iter (fun line ->
        Buffer.add_string buf ("data: " ^ line ^ "\n"));
   (* 3. id *)

--- a/test/test_sse_suite.ml
+++ b/test/test_sse_suite.ml
@@ -55,6 +55,79 @@ let test_sse_ping () =
   let ping = Kirin.sse_ping in
   check string "ping format" ": ping\n\n" ping
 
+(* SSE wire format is line-oriented and the HTML spec treats CR,
+   LF, and CRLF as line breaks.  Before this PR, [encode] passed
+   the [event] and [id] fields through to the wire as-is, so a
+   single string crossing the boundary could inject extra SSE
+   rows — different [event] type, additional [data], a forged
+   [id].  That is SSE protocol injection.  New contract:
+
+   - [event] and [id] reject CR/LF at encode time
+   - [data] is the only multi-line field, and splits on CR, LF,
+     and CRLF — so a stray [\r] no longer escapes onto the wire
+     as a receiver-side line break *)
+
+let test_encode_rejects_event_type_lf () =
+  check_raises "LF in event type"
+    (Invalid_argument
+       "Sse.encode: event field contains CR/LF; SSE protocol injection rejected")
+    (fun () ->
+       ignore
+         (Kirin.sse_encode (Kirin.sse_event "msg\ndata: takeover" "x")))
+
+let test_encode_rejects_event_type_cr () =
+  check_raises "CR in event type"
+    (Invalid_argument
+       "Sse.encode: event field contains CR/LF; SSE protocol injection rejected")
+    (fun () ->
+       ignore (Kirin.sse_encode (Kirin.sse_event "msg\rxxx" "x")))
+
+let test_encode_rejects_id_lf () =
+  check_raises "LF in id"
+    (Invalid_argument
+       "Sse.encode: id field contains CR/LF; SSE protocol injection rejected")
+    (fun () ->
+       ignore
+         (Kirin.sse_encode
+            (Kirin.sse_data "d" |> Kirin.sse_with_id "1\ndata: forged")))
+
+let test_encode_rejects_id_cr () =
+  check_raises "CR in id"
+    (Invalid_argument
+       "Sse.encode: id field contains CR/LF; SSE protocol injection rejected")
+    (fun () ->
+       ignore
+         (Kirin.sse_encode
+            (Kirin.sse_data "d" |> Kirin.sse_with_id "1\revil")))
+
+let test_encode_data_splits_on_cr () =
+  (* A standalone CR in [data] used to escape onto the wire and
+     be treated as a line break by the receiver — same injection
+     surface as a literal newline.  Pin that we now split on CR
+     and emit two data rows. *)
+  let evt = Kirin.sse_data "alpha\rbeta" in
+  check string "CR splits data"
+    "data: alpha\ndata: beta\n\n"
+    (Kirin.sse_encode evt)
+
+let test_encode_data_splits_on_crlf () =
+  let evt = Kirin.sse_data "line1\r\nline2\r\nline3" in
+  check string "CRLF is one break, not two"
+    "data: line1\ndata: line2\ndata: line3\n\n"
+    (Kirin.sse_encode evt)
+
+let test_encode_event_safe_alphanumerics_unchanged () =
+  (* Pin that ordinary event/id values still pass through — the
+     validator is not over-eager. *)
+  let evt =
+    Kirin.sse_event "update" "payload"
+    |> Kirin.sse_with_id "abc-123"
+    |> Kirin.sse_with_retry 1500
+  in
+  check string "safe event"
+    "event: update\ndata: payload\nid: abc-123\nretry: 1500\n\n"
+    (Kirin.sse_encode evt)
+
 let tests = [
   test_case "encode simple" `Quick test_sse_encode_simple;
   test_case "encode multiline" `Quick test_sse_encode_multiline;
@@ -64,4 +137,11 @@ let tests = [
   test_case "encode full" `Quick test_sse_encode_full;
   test_case "response headers" `Quick test_sse_response;
   test_case "ping" `Quick test_sse_ping;
+  test_case "encode rejects LF in event type" `Quick test_encode_rejects_event_type_lf;
+  test_case "encode rejects CR in event type" `Quick test_encode_rejects_event_type_cr;
+  test_case "encode rejects LF in id" `Quick test_encode_rejects_id_lf;
+  test_case "encode rejects CR in id" `Quick test_encode_rejects_id_cr;
+  test_case "encode data splits on CR" `Quick test_encode_data_splits_on_cr;
+  test_case "encode data splits on CRLF" `Quick test_encode_data_splits_on_crlf;
+  test_case "encode safe alphanumerics unchanged" `Quick test_encode_event_safe_alphanumerics_unchanged;
 ]


### PR DESCRIPTION
## 요약

\`Sse.encode\`가 \`event\` 타입과 \`id\` 필드를 \`Buffer.add_string (\"event: \" ^ t ^ \"\\n\")\` / \`\"id: \" ^ id ^ \"\\n\"\`로 wire에 그대로 보간. SSE wire format은 line-oriented이며 **HTML living standard는 CR, LF, CRLF 모두 line break로 취급**. caller가 \`event=\"msg\\ndata: takeover\"\` 같은 값을 흘리면:

\`\`\`
event: msg
data: takeover

data: <원래 data>
\`\`\`

즉 *추가 SSE 행*이 wire에 주입됨. **SSE protocol injection**: producer가 단일 string으로 다른 event type / 추가 data / 위조된 id를 receiver에 forge할 수 있음.

\`data\` 필드도 평행 결함: splitter가 \`\\n\`만 인식 → standalone \`\\r\`이 wire로 escape → receiver가 line break로 해석 → 같은 인젝션을 다른 경로로.

## 변경

**\`lib/sse.ml\`**
- \`validate_single_line ~field\`: \`event\` / \`id\`에서 CR/LF 발견 시 \`Invalid_argument\` (필드명 명시).
- \`split_sse_lines\`: \`data\`를 CR, LF, CRLF로 split (CRLF는 *하나의* break, 두 empty row 아님). HTML SSE spec의 receiver-side line-break rule과 일치.
- \`encode\`이 \`Option.iter validate_single_line\`로 event/id 사전 검증 + \`split_sse_lines\`로 data multi-line.

**\`test/test_sse_suite.ml\`** — 7 신규 (SSE 그룹, 15 total):

- **\`encode rejects LF in event type\`** / **\`encode rejects CR in event type\`** — 분리 케이스 핀.
- **\`encode rejects LF in id\`** / **\`encode rejects CR in id\`** — id 인젝션 차단.
- **\`encode data splits on CR\`** — \`\"alpha\\rbeta\"\` → 두 \`data:\` 행.
- **\`encode data splits on CRLF\`** — CRLF가 *하나의* break (empty row 아님).
- **positive**: 일반 alphanumeric event/id는 byte-identical (validator over-eager 방지).

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **235 tests pass** (기존 228 + 신규 7).
- SSE 그룹 15/15 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 인젝션 surface를 *닫음*.
- ❌ string 분류기 아님 — byte-level reject + typed split.
- ❌ N-of-M 아님 — \`encode\` 단일 진입점에서 두 surface(event/id reject + data split) 동시 fix.
- ❌ catch-all 아님 — \`Invalid_argument\`로 fail-loud.

## RFC

\`RFC-WAIVED: SSE 프로토콜 인젝션 boundary fix. 외부 API는 \`encode\`가 CR/LF 들어있는 event/id에 raise하는 contract 추가 (이전엔 silent malformed wire). backwards compatible — 정상 입력 byte-identical.\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>