### PR TITLE
fix(multipart): RFC 2046 boundary validation; cap part count

### DIFF
--- a/lib/multipart.ml
+++ b/lib/multipart.ml
@@ -13,14 +13,60 @@ type t = {
   parts : part list;
 }
 
-(** Extract boundary from Content-Type header *)
+(* RFC 2046 §5.1.1 — boundary is 1..70 characters from a restricted
+   character class.  Beyond the spec, three concrete misparses fall
+   out of accepting anything:
+
+   - empty boundary  → delimiter is just "--", which appears all
+     over real bodies and turns the parser into garbage
+   - whitespace-only / CR-LF in boundary → splitter aligns on bytes
+     that occur naturally in part headers, again producing garbage
+   - 70+ char boundary → spec-violating sender; tolerating it
+     makes denial-of-service easier (the value still has to be
+     searched linearly against the whole body)
+
+   Reject these at [extract_boundary] so an attacker-shaped header
+   never reaches [parse].  Returning [None] is the existing failure
+   shape: [from_request] already maps it to a no-multipart request. *)
+let is_valid_boundary_char c =
+  (c >= 'a' && c <= 'z')
+  || (c >= 'A' && c <= 'Z')
+  || (c >= '0' && c <= '9')
+  || c = '\'' || c = '(' || c = ')' || c = '+' || c = '_'
+  || c = ',' || c = '-' || c = '.' || c = '/' || c = ':'
+  || c = '=' || c = '?' || c = ' '
+
+let boundary_is_rfc2046_valid s =
+  let n = String.length s in
+  if n < 1 || n > 70 then false
+  else begin
+    let ok = ref true in
+    String.iter (fun c -> if not (is_valid_boundary_char c) then ok := false) s;
+    !ok
+  end
+
+(* Strip a single layer of double-quotes if present (some senders
+   wrap the boundary as [boundary="..."]).  Done before the
+   character-class check so [boundary="abc"] passes. *)
+let unquote s =
+  let n = String.length s in
+  if n >= 2 && s.[0] = '"' && s.[n - 1] = '"'
+  then String.sub s 1 (n - 2)
+  else s
+
+(** Extract boundary from Content-Type header.
+    Returns [None] when the boundary parameter is absent, empty,
+    longer than RFC 2046's 70-char limit, or contains bytes outside
+    the spec's allowed class. *)
 let extract_boundary content_type =
   (* Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW *)
   let parts = String.split_on_char ';' content_type in
   List.find_map (fun part ->
     let part = String.trim part in
     if String.length part > 9 && String.sub part 0 9 = "boundary=" then
-      Some (String.sub part 9 (String.length part - 9))
+      let raw = String.sub part 9 (String.length part - 9) in
+      let b = unquote raw in
+      if boundary_is_rfc2046_valid b then Some b else None
     else
       None
   ) parts
@@ -104,53 +150,84 @@ let parse_part content =
   | Some name -> Some { name; filename; content_type; content = body }
   | None -> None
 
-(** Parse multipart form data *)
-let parse ~boundary body =
+(** Default cap on the number of parts the splitter will accumulate.
+    A normal form has a handful; anything past the cap is almost
+    certainly a denial-of-service shape (an attacker driving the
+    parser into [O(N * body)] [String.sub] allocations by repeating
+    boundaries).  Real forms never approach this. *)
+let default_max_parts = 1000
+
+(** Parse multipart form data.
+
+    [?max_parts] caps the number of part fragments the splitter
+    keeps.  Once the cap is hit, the entire result is discarded
+    and an empty [{parts = []}] is returned — *not* a truncated
+    partial parse — because a partial result is attacker-shaped
+    and may be more dangerous than no result at all. *)
+let parse ?(max_parts = default_max_parts) ~boundary body =
   let delimiter = "--" ^ boundary in
   let _end_delimiter = delimiter ^ "--" in
 
+  let overflow = ref false in
+  let take_or_overflow acc part_content =
+    if List.length acc >= max_parts then begin
+      overflow := true;
+      acc
+    end else
+      part_content :: acc
+  in
+
   (* Split by delimiter *)
   let rec split_parts acc start =
-    match find_substring body delimiter start with
-    | None -> List.rev acc
-    | Some idx ->
-      if idx > start then begin
-        (* Content before this delimiter *)
-        let part_content = String.sub body start (idx - start) in
-        (* Remove trailing \r\n *)
-        let part_content =
-          let len = String.length part_content in
-          if len >= 2 && String.sub part_content (len - 2) 2 = "\r\n"
-          then String.sub part_content 0 (len - 2)
-          else part_content
-        in
-        if String.length part_content > 0 then
-          split_parts (part_content :: acc) (idx + String.length delimiter)
-        else
-          split_parts acc (idx + String.length delimiter)
-      end else begin
-        (* Skip to after delimiter *)
-        let after_delim = idx + String.length delimiter in
-        (* Check if this is end delimiter *)
-        if after_delim + 2 <= String.length body &&
-           String.sub body after_delim 2 = "--"
-        then List.rev acc
-        else begin
-          (* Skip \r\n after delimiter *)
-          let next_start =
-            if after_delim + 2 <= String.length body &&
-               String.sub body after_delim 2 = "\r\n"
-            then after_delim + 2
-            else after_delim
+    if !overflow then acc
+    else
+      match find_substring body delimiter start with
+      | None -> List.rev acc
+      | Some idx ->
+        if idx > start then begin
+          (* Content before this delimiter *)
+          let part_content = String.sub body start (idx - start) in
+          (* Remove trailing \r\n *)
+          let part_content =
+            let len = String.length part_content in
+            if len >= 2 && String.sub part_content (len - 2) 2 = "\r\n"
+            then String.sub part_content 0 (len - 2)
+            else part_content
           in
-          split_parts acc next_start
+          if String.length part_content > 0 then
+            split_parts (take_or_overflow acc part_content) (idx + String.length delimiter)
+          else
+            split_parts acc (idx + String.length delimiter)
+        end else begin
+          (* Skip to after delimiter *)
+          let after_delim = idx + String.length delimiter in
+          (* Check if this is end delimiter *)
+          if after_delim + 2 <= String.length body &&
+             String.sub body after_delim 2 = "--"
+          then List.rev acc
+          else begin
+            (* Skip \r\n after delimiter *)
+            let next_start =
+              if after_delim + 2 <= String.length body &&
+                 String.sub body after_delim 2 = "\r\n"
+              then after_delim + 2
+              else after_delim
+            in
+            split_parts acc next_start
+          end
         end
-      end
   in
 
   let raw_parts = split_parts [] 0 in
-  let parts = List.filter_map parse_part raw_parts in
-  { parts }
+  if !overflow then
+    (* Refuse to expose a partial parse — log nothing here (the
+       caller's middleware decides on telemetry) and return the
+       empty multipart so the request looks like one with no
+       parts. *)
+    { parts = [] }
+  else
+    let parts = List.filter_map parse_part raw_parts in
+    { parts }
 
 (** Parse multipart from request *)
 let from_request req =

--- a/lib/multipart.mli
+++ b/lib/multipart.mli
@@ -21,13 +21,32 @@ type t
 
 (** {1 Parsing} *)
 
+(** Default cap on the number of parts [parse] will accumulate
+    before refusing the whole body (1000).  Real forms never come
+    close; the cap exists to bound DoS shapes that drive the
+    splitter into many [String.sub] allocations. *)
+val default_max_parts : int
+
 (** [extract_boundary content_type] extracts the boundary string
-    from a Content-Type header value. *)
+    from a Content-Type header value.
+
+    Returns [None] when the boundary parameter is absent, empty,
+    longer than RFC 2046's 70-char limit, or contains bytes
+    outside the spec's allowed character class.  A double-quoted
+    boundary (e.g. [boundary="abc"]) is unquoted before the
+    character-class check. *)
 val extract_boundary : string -> string option
 
-(** [parse ~boundary body] parses a multipart body using the given
-    boundary delimiter. *)
-val parse : boundary:string -> string -> t
+(** [parse ?max_parts ~boundary body] parses a multipart body
+    using the given boundary delimiter.
+
+    [max_parts] (default {!default_max_parts}) caps the number of
+    fragments the splitter accumulates.  Once the cap is hit the
+    entire result is discarded and an empty multipart is returned
+    — *not* a truncated partial parse — because an attacker who
+    drove the parser past the cap could otherwise steer
+    downstream code through a partial-view shape. *)
+val parse : ?max_parts:int -> boundary:string -> string -> t
 
 (** [from_request req] parses multipart form data from a request.
     Returns [None] if the Content-Type is not multipart/form-data

--- a/test/test_multipart_suite.ml
+++ b/test/test_multipart_suite.ml
@@ -65,9 +65,107 @@ let test_multipart_mixed () =
   check int "files count" 1 (List.length (Kirin.Multipart.files result));
   check int "fields count" 1 (List.length (Kirin.Multipart.fields result))
 
+(* Boundary validation regression tests.  RFC 2046 §5.1.1 requires
+   boundaries to be 1..70 characters from a restricted class; the
+   old [extract_boundary] returned anything after "boundary=", so
+   a sender that passed [boundary=] (empty) made the delimiter
+   just "--", which appears all over real bodies and turned the
+   parser into garbage. *)
+
+let test_extract_boundary_rejects_empty () =
+  check (option string) "empty boundary -> None"
+    None
+    (Kirin.Multipart.extract_boundary "multipart/form-data; boundary=")
+
+let test_extract_boundary_rejects_too_long () =
+  let long = String.make 71 'a' in
+  check (option string) "71-char boundary -> None"
+    None
+    (Kirin.Multipart.extract_boundary
+       (Printf.sprintf "multipart/form-data; boundary=%s" long));
+  let just_at_limit = String.make 70 'a' in
+  check (option string) "70-char boundary -> Some"
+    (Some just_at_limit)
+    (Kirin.Multipart.extract_boundary
+       (Printf.sprintf "multipart/form-data; boundary=%s" just_at_limit))
+
+let test_extract_boundary_rejects_disallowed_bytes () =
+  check (option string) "boundary with CR"
+    None
+    (Kirin.Multipart.extract_boundary "multipart/form-data; boundary=ab\rcd");
+  check (option string) "boundary with LF"
+    None
+    (Kirin.Multipart.extract_boundary "multipart/form-data; boundary=ab\ncd");
+  check (option string) "boundary with NUL"
+    None
+    (Kirin.Multipart.extract_boundary "multipart/form-data; boundary=ab\x00cd");
+  check (option string) "boundary with tab"
+    None
+    (Kirin.Multipart.extract_boundary "multipart/form-data; boundary=ab\tcd")
+
+let test_extract_boundary_accepts_quoted () =
+  (* Some senders wrap the boundary as [boundary="abc"]; unquote
+     before the character-class check so this still passes. *)
+  check (option string) "quoted boundary"
+    (Some "abc-123")
+    (Kirin.Multipart.extract_boundary
+       "multipart/form-data; boundary=\"abc-123\"")
+
+(* [max_parts] cap regression test.  A malicious body with many
+   short parts used to drive the splitter into unbounded
+   [String.sub] allocations and an unbounded result list.  The
+   new contract: once the cap is exceeded the entire parse is
+   refused (empty multipart returned), so downstream code does
+   not see an attacker-shaped partial view. *)
+let test_parse_caps_part_count () =
+  let boundary = "----testboundary" in
+  let buf = Buffer.create 8192 in
+  for i = 0 to 9 do
+    Buffer.add_string buf "------testboundary\r\n";
+    Buffer.add_string buf
+      (Printf.sprintf "Content-Disposition: form-data; name=\"f%d\"\r\n" i);
+    Buffer.add_string buf "\r\n";
+    Buffer.add_string buf (Printf.sprintf "v%d\r\n" i)
+  done;
+  Buffer.add_string buf "------testboundary--\r\n";
+  let body = Buffer.contents buf in
+  (* Default cap (1000) allows 10 parts through. *)
+  let normal = Kirin.Multipart.parse ~boundary body in
+  check int "10 parts under default cap" 10
+    (List.length (Kirin.Multipart.fields normal));
+  (* Cap=3 should refuse the whole body and return zero parts —
+     not a 3-part truncation. *)
+  let capped = Kirin.Multipart.parse ~max_parts:3 ~boundary body in
+  check int "over-cap body -> empty result" 0
+    (List.length (Kirin.Multipart.fields capped))
+
+let test_parse_at_cap_succeeds () =
+  (* Boundary case: exactly [max_parts] fragments must succeed,
+     not get refused.  The refusal is for *exceeding* the cap. *)
+  let boundary = "----testboundary" in
+  let buf = Buffer.create 4096 in
+  for i = 0 to 2 do
+    Buffer.add_string buf "------testboundary\r\n";
+    Buffer.add_string buf
+      (Printf.sprintf "Content-Disposition: form-data; name=\"f%d\"\r\n" i);
+    Buffer.add_string buf "\r\n";
+    Buffer.add_string buf (Printf.sprintf "v%d\r\n" i)
+  done;
+  Buffer.add_string buf "------testboundary--\r\n";
+  let body = Buffer.contents buf in
+  let r = Kirin.Multipart.parse ~max_parts:3 ~boundary body in
+  check int "exactly 3 parts at cap" 3
+    (List.length (Kirin.Multipart.fields r))
+
 let tests = [
   test_case "extract boundary" `Quick test_multipart_extract_boundary;
   test_case "parse simple form" `Quick test_multipart_parse_simple;
   test_case "parse file upload" `Quick test_multipart_parse_file;
   test_case "parse mixed form" `Quick test_multipart_mixed;
+  test_case "extract boundary rejects empty" `Quick test_extract_boundary_rejects_empty;
+  test_case "extract boundary rejects too long" `Quick test_extract_boundary_rejects_too_long;
+  test_case "extract boundary rejects disallowed bytes" `Quick test_extract_boundary_rejects_disallowed_bytes;
+  test_case "extract boundary accepts quoted" `Quick test_extract_boundary_accepts_quoted;
+  test_case "parse caps part count and refuses overflow" `Quick test_parse_caps_part_count;
+  test_case "parse at exact cap succeeds" `Quick test_parse_at_cap_succeeds;
 ]


### PR DESCRIPTION
## 요약

\`Kirin.Multipart\`의 두 결함 동시 fix.

### 1. Boundary 검증 부재

\`extract_boundary\`가 \`boundary=\` 뒤에 오는 *모든* 문자열을 그대로 반환:
- 빈 boundary → delimiter=\`\"--\"\` → real body 거의 어디든 매치 → parser garbage.
- CR/LF/NUL/tab 포함 boundary → splitter가 part header 안의 동일 바이트와 align → garbage.
- 70+ chars boundary → RFC 2046 §5.1.1 위반 + 전체 body에 대해 linear search 비용 증가 (DoS amplification).

### 2. Part count 무제한 (DoS)

\`parse\`가 part 개수 cap 없음. 짧은 part 수십만 개 body가 들어오면 \`O(N * body)\` \`String.sub\` allocation + 무한 list 누적.

## 변경

**\`lib/multipart.ml\`** + **\`lib/multipart.mli\`**:

- \`is_valid_boundary_char\` + \`boundary_is_rfc2046_valid\`: RFC 2046 §5.1.1 character class + 1..70 길이 검증.
- \`unquote\`: \`boundary=\"...\"\` 형태 한 겹 unwrap (일부 sender).
- \`extract_boundary\`이 invalid면 \`None\` 반환 (\`from_request\`가 기존부터 \`None\` → no-multipart로 매핑하므로 caller 호환).
- \`?max_parts:int\` (default 1000) — splitter overflow ref로 cap 초과 검출. 초과 시 *전체* parse 거부, 빈 \`{ parts = [] }\` 반환 — 부분 parse는 attacker-shaped일 수 있으므로 fail-loud보다 *fail-empty* 안전.
- mli에 \`default_max_parts\` + 새 옵션 시그니처 노출.

**\`test/test_multipart_suite.ml\`** — 6 신규 (Multipart 그룹, 10 total):

- **boundary**: 빈 / 71-char(reject) vs 70-char(accept) / CR/LF/NUL/tab 각각 / quoted boundary positive.
- **part cap**: 10-part body가 default cap에서 통과; \`~max_parts:3\` + 10-part body → 0 fields (not 3 truncated); exactly 3 parts at cap=3 → 통과 (boundary case 핀, 미래 off-by-one 회귀 차단).

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **234 tests pass** (기존 228 + 신규 6).
- Multipart 그룹 10/10 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 DoS surface와 boundary parser garbage를 *닫음*.
- ❌ string 분류기 아님 — typed character class (\`is_valid_boundary_char\`) + length range.
- ❌ N-of-M 아님 — 단일 모듈 두 surface (boundary + part cap) 동시.
- ✅ cap 사용 (\`max_parts\`) — 하지만 *symptom 억제용 cap이 아니라 DoS resource bound*. PR body에 deprecation 경로 없음 (이게 의도된 동작). RFC scope 아님.

## RFC

\`RFC-WAIVED: multipart parser DoS + boundary garbage fix. 외부 API에 \`?max_parts\` 옵션 + \`default_max_parts\` 노출 (backwards compatible — 기본값 1000은 정상 form 영향 없음, 명시적 boundary 검증은 invalid input에 limit to None mapping 변경).\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>