### PR TITLE
fix(shutdown): wait_for_drain must observe config.timeout

### DIFF
--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -150,15 +150,42 @@ let run_hooks t =
 
 (** {1 Shutdown Process} *)
 
-(** Wait for connections to drain *)
+(* Poll-based drain that *actually* honours [config.timeout].
+
+   The previous implementation called [Eio.Condition.await] inside
+   a [now () < deadline] while-loop.  [await] has no timeout
+   parameter — it only returns when [connection_end] broadcasts.
+   If every active connection is stuck (slow client, deadlocked
+   handler, dropped socket without RST), [connection_end] is never
+   called, no broadcast arrives, and [await] waits forever.  The
+   [now () < deadline] guard is never re-evaluated, so the
+   configured timeout is silently dead: K8s has to send SIGKILL
+   after [terminationGracePeriodSeconds] to actually stop the
+   process and the graceful-drain contract is broken.
+
+   Switch to a short [Time_compat.sleep] poll loop so the deadline
+   is observed independent of any broadcast.  Polling is wasteful
+   in steady state, but [wait_for_drain] only runs once per
+   process lifetime, and 50ms is fine-grained enough that the
+   typical drain finishes in one or two cycles. *)
+let wait_for_drain_poll_interval = 0.05
+
 let wait_for_drain t =
   let deadline = now () +. t.config.timeout in
-  Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
-    while t.active_connections > 0 && now () < deadline do
-      Eio.Condition.await t.condition t.mutex
-    done;
-    t.active_connections = 0
-  )
+  let drained = ref false in
+  let timed_out = ref false in
+  while not !drained && not !timed_out do
+    let count = with_lock t (fun () -> t.active_connections) in
+    if count = 0 then drained := true
+    else if now () >= deadline then timed_out := true
+    else begin
+      let remaining = deadline -. now () in
+      let s = min wait_for_drain_poll_interval (max 0.0 remaining) in
+      if s > 0.0 then Time_compat.sleep s
+      else timed_out := true
+    end
+  done;
+  !drained
 
 (** Initiate graceful shutdown *)
 let initiate t =

--- a/test/test_shutdown_suite.ml
+++ b/test/test_shutdown_suite.ml
@@ -53,6 +53,65 @@ let test_shutdown_status_json () =
     check bool "has connections" true (List.mem_assoc "active_connections" fields)
   | _ -> fail "expected JSON object"
 
+(* Before this PR, [wait_for_drain] called [Eio.Condition.await]
+   inside a [now () < deadline] while-loop.  [await] has no
+   timeout parameter, so a connection that never calls
+   [connection_end] (slow client, deadlocked handler, dropped
+   socket without RST) left the wait hanging forever — the
+   configured [timeout] was silently dead and K8s had to SIGKILL
+   the process after [terminationGracePeriodSeconds].
+
+   These tests pin the new contract: [initiate] returns within
+   approximately [timeout] seconds even when no connection ever
+   ends, and still drains promptly in the normal case. *)
+
+let test_initiate_honours_timeout_when_drain_hangs () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Kirin.Time_compat.set_clock clock;
+  Fun.protect
+    ~finally:(fun () -> Kirin.Time_compat.clear_clock ())
+    (fun () ->
+      let shutdown = S.create ~timeout:0.15 () in
+      let started = S.connection_start shutdown in
+      check bool "stuck connection registered" true started;
+      let t0 = Unix.gettimeofday () in
+      S.initiate shutdown;
+      let elapsed = Unix.gettimeofday () -. t0 in
+      (* The drain must give up between [timeout] and a small
+         margin (poll interval + scheduler jitter).  Before this
+         PR it would hang indefinitely. *)
+      check bool
+        (Printf.sprintf "initiate returned in %.3fs (~timeout 0.15s)" elapsed)
+        true
+        (elapsed >= 0.15 && elapsed < 1.0);
+      (* State must be Stopped even after a force-timeout drain. *)
+      check bool "stopped after forced drain" true (S.is_stopped shutdown))
+
+let test_initiate_drains_promptly_in_normal_case () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Kirin.Time_compat.set_clock clock;
+  Fun.protect
+    ~finally:(fun () -> Kirin.Time_compat.clear_clock ())
+    (fun () ->
+      Eio.Switch.run @@ fun sw ->
+      let shutdown = S.create ~timeout:5.0 () in
+      let _ = S.connection_start shutdown in
+      (* End the connection 50ms after initiate begins. *)
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Time.sleep clock 0.05;
+        S.connection_end shutdown);
+      let t0 = Unix.gettimeofday () in
+      S.initiate shutdown;
+      let elapsed = Unix.gettimeofday () -. t0 in
+      (* Drain returned well before the 5s timeout. *)
+      check bool
+        (Printf.sprintf "drained in %.3fs (< 1s)" elapsed)
+        true
+        (elapsed < 1.0);
+      check bool "stopped" true (S.is_stopped shutdown))
+
 let tests = [
   test_case "shutdown create" `Quick (with_eio test_shutdown_create);
   test_case "shutdown custom timeout" `Quick (with_eio test_shutdown_custom_timeout);
@@ -60,4 +119,6 @@ let tests = [
   test_case "shutdown connection tracking" `Quick (with_eio test_shutdown_connection_tracking);
   test_case "shutdown reject during" `Quick test_shutdown_reject_during_shutdown;
   test_case "shutdown status json" `Quick (with_eio test_shutdown_status_json);
+  test_case "initiate honours timeout when drain hangs" `Quick test_initiate_honours_timeout_when_drain_hangs;
+  test_case "initiate drains promptly in normal case" `Quick test_initiate_drains_promptly_in_normal_case;
 ]


### PR DESCRIPTION
## 요약

\`Shutdown.wait_for_drain\` (lib/shutdown.ml:152-160)이 \`Eio.Condition.await\`을 \`now () < deadline\` while-loop 안에서 호출. \`Eio.Condition.await\`은 *timeout parameter가 없음* — \`connection_end\`이 broadcast해야 깨어남.

**Silent dead config**: 만약 active connection이 *전부 hang* (slow client / deadlocked handler / dropped socket without RST) → \`connection_end\` 호출 안 됨 → broadcast 없음 → \`await\` 영원히 wait. \`now () < deadline\` guard는 *다음 broadcast 시*에만 re-evaluate → 영원히 hang.

**Production impact**: K8s가 \`terminationGracePeriodSeconds\` 후 SIGKILL을 보내야만 process 종료. graceful-drain의 contract 무력화. PR #59 jobs \`retry_delay\` / PR #65 ratelimit XFF / PR #61 health drain과 같은 silent dead config 패턴.

## 변경

**\`lib/shutdown.ml\`** — \`wait_for_drain\` 재작성:

- \`Eio.Condition.await\` 폐기.
- 50ms 폴링 (\`Time_compat.sleep\` — Eio clock 설치 시 fiber-aware, 미설치 시 \`Unix.sleepf\` fallback). 매 poll에서 \`active_connections\` + deadline 체크.
- \`drained\` / \`timed_out\` 두 ref로 결정 → deadline이 broadcast와 독립적으로 observed.

폴링은 steady state에서 wasteful이지만 \`wait_for_drain\`은 *프로세스 lifetime 1회* 호출 + 정상 drain은 1-2 cycle 안 종료.

**\`test/test_shutdown_suite.ml\`** — 2 신규 (Shutdown 그룹, 8 total):

- **\`initiate honours timeout when drain hangs\`** — connection 등록 + \`connection_end\` *호출 안 함* + \`~timeout:0.15\` + wall-clock 측정. \`elapsed ∈ [0.15s, 1.0s]\` 핀. PR 이전엔 *영원히 hang*했을 시나리오.
- **\`initiate drains promptly in normal case\`** — connection 등록, 50ms 후 fiber에서 \`connection_end\`, \`~timeout:5.0\`. \`elapsed < 1s\` 핀 (전체 timeout 안 기다림) + \`Stopped\` 상태 확인.

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **230 tests pass** in 0.47s (기존 228 + 신규 2).
- Shutdown 그룹 8/8 OK.
- 신규 회귀 테스트가 *기존 코드라면 무한 hang*하던 시나리오를 0.15s 안에 종료시킴 → silent dead config의 fix를 *직접 측정*.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 hang shape를 *차단*.
- ❌ string 분류기 아님.
- ❌ N-of-M 아님 — \`wait_for_drain\` 단일 함수.
- ❌ catch-all/cap 안티패턴 아님 — \`timeout\`은 user-configurable graceful-drain 상한, suppression cap이 아님.

## RFC

\`RFC-WAIVED: graceful shutdown 시멘틱 회복 (dead config 활성화). 외부 API contract 변경 없음 (\`timeout\`이 *실제로* 상한이 되는 것뿐, backwards compatible).\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>