### PR TITLE
fix(pool): acquire must observe config.max_wait_time

### DIFF
--- a/lib/pool.ml
+++ b/lib/pool.ml
@@ -209,11 +209,41 @@ let size pool =
     (pool.in_use, List.length pool.connections, pool.config.max_size)
   )
 
+(* Poll-based acquire that *actually* honours
+   [config.max_wait_time].
+
+   The previous implementation called [Eio.Condition.await] inside
+   an [elapsed > max_wait_time] guard.  Two failure shapes fell
+   out of that:
+
+   - [await] has no deadline parameter.  If every in-use
+     connection hangs (slow downstream / deadlocked handler /
+     dropped socket), [release] is never called, the condition
+     never broadcasts, and the wait blocks forever.  The
+     elapsed-time guard is only re-checked on the next broadcast,
+     so the configured [max_wait_time] is silently dead — same
+     shape as the shutdown drain bug, but with a wider blast
+     radius because the pool is the chokepoint for every
+     database / HTTP call.
+
+   - Lost-wakeup race: [try_acquire] returns [None], a concurrent
+     fiber [release]s and broadcasts before this fiber re-enters
+     [await], and the broadcast is lost.  The pooled connection
+     sits idle while this fiber waits for the *next* broadcast.
+
+   Switch to a short [Time_compat.sleep] poll loop.  The deadline
+   is now observed independent of any broadcast and lost-wakeups
+   cannot hold a fiber past the timeout.  Polling at 50ms is
+   wasteful in steady state, but [acquire] only polls when the
+   pool is genuinely at capacity, and the typical loop body runs
+   in a few iterations. *)
+let acquire_poll_interval = 0.05
+
 (** Acquire a connection from the pool.
 
-    Blocks if no connections are available and pool is at max capacity.
-    Raises Pool_error(Timeout) if max_wait_time is exceeded.
-*)
+    Blocks if no connections are available and pool is at max
+    capacity.  Raises [Pool_error Timeout] when [max_wait_time]
+    elapses without a connection becoming free. *)
 let acquire pool =
   let start_time = now () in
 
@@ -254,26 +284,33 @@ let acquire pool =
     )
   in
 
-  let rec wait_for_connection () =
-    let elapsed = now () -. start_time in
-    if elapsed > pool.config.max_wait_time then begin
-      update_stats pool (fun s -> { s with total_timeouts = s.total_timeouts + 1 });
-      raise (Pool_error Timeout)
-    end;
-
-    match try_acquire () with
-    | Some pooled -> pooled
-    | None ->
-      (* Wait for a connection to be released *)
-      Eio.Mutex.use_rw ~protect:true pool.mutex (fun () ->
-        pool.waiting <- pool.waiting + 1;
-        Eio.Condition.await pool.condition pool.mutex;
-        pool.waiting <- pool.waiting - 1
-      );
-      wait_for_connection ()
+  let bump_waiting d =
+    with_lock pool.mutex (fun () -> pool.waiting <- pool.waiting + d)
+  in
+  let timed_out () =
+    update_stats pool (fun s -> { s with total_timeouts = s.total_timeouts + 1 });
+    raise (Pool_error Timeout)
   in
 
-  wait_for_connection ()
+  bump_waiting 1;
+  Fun.protect
+    ~finally:(fun () -> bump_waiting (-1))
+    (fun () ->
+      let rec loop () =
+        match try_acquire () with
+        | Some pooled -> pooled
+        | None ->
+          let elapsed = now () -. start_time in
+          if elapsed >= pool.config.max_wait_time then timed_out ()
+          else begin
+            let remaining = pool.config.max_wait_time -. elapsed in
+            let s = min acquire_poll_interval (max 0.0 remaining) in
+            if s > 0.0 then Time_compat.sleep s
+            else timed_out ();
+            loop ()
+          end
+      in
+      loop ())
 
 (** Release a connection back to the pool *)
 let release pool pooled =

--- a/test/test_pool_suite.ml
+++ b/test/test_pool_suite.ml
@@ -90,6 +90,79 @@ let test_pool_error_to_string () =
   check string "exhausted error" "Connection pool exhausted"
     (Kirin.Pool.error_to_string Kirin.Pool.Pool_exhausted)
 
+(* Before this PR, [acquire]'s wait loop used [Eio.Condition.await]
+   inside an elapsed-time guard.  [await] has no deadline parameter,
+   so if every in-use connection hung (slow downstream / deadlocked
+   handler / dropped socket) [release] never broadcast and the wait
+   blocked forever — the configured [max_wait_time] was silently
+   dead.  Pin the new contract: [acquire] raises [Pool_error Timeout]
+   within approximately [max_wait_time] seconds even when no
+   connection is ever released. *)
+
+let test_acquire_honours_max_wait_time_when_all_connections_hang () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Kirin.Time_compat.set_clock clock;
+  Fun.protect
+    ~finally:(fun () -> Kirin.Time_compat.clear_clock ())
+    (fun () ->
+      let pool = Kirin.Pool.create
+        ~min_size:0
+        ~max_size:1
+        ~max_wait_time:0.15
+        ~create:(fun () -> "conn")
+        ~destroy:(fun _ -> ())
+        ()
+      in
+      (* Take the only slot and never release it. *)
+      let _held = Kirin.Pool.acquire pool in
+      let t0 = Unix.gettimeofday () in
+      let raised =
+        try
+          let _ = Kirin.Pool.acquire pool in
+          `Got_connection
+        with Kirin.Pool.Pool_error Kirin.Pool.Timeout -> `Timed_out
+      in
+      let elapsed = Unix.gettimeofday () -. t0 in
+      check bool "second acquire raised Timeout"
+        true
+        (raised = `Timed_out);
+      check bool
+        (Printf.sprintf "elapsed %.3fs ∈ [0.15, 1.0]" elapsed)
+        true
+        (elapsed >= 0.15 && elapsed < 1.0);
+      let s = Kirin.Pool.stats pool in
+      check int "timeout counted in stats" 1 s.total_timeouts)
+
+let test_acquire_succeeds_quickly_when_connection_released () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Kirin.Time_compat.set_clock clock;
+  Fun.protect
+    ~finally:(fun () -> Kirin.Time_compat.clear_clock ())
+    (fun () ->
+      Eio.Switch.run @@ fun sw ->
+      let pool = Kirin.Pool.create
+        ~min_size:0
+        ~max_size:1
+        ~max_wait_time:5.0
+        ~create:(fun () -> "conn")
+        ~destroy:(fun _ -> ())
+        ()
+      in
+      let first = Kirin.Pool.acquire pool in
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Time.sleep clock 0.05;
+        Kirin.Pool.release pool first);
+      let t0 = Unix.gettimeofday () in
+      let _ = Kirin.Pool.acquire pool in
+      let elapsed = Unix.gettimeofday () -. t0 in
+      (* Returned well before the 5s timeout. *)
+      check bool
+        (Printf.sprintf "acquired in %.3fs (< 1s)" elapsed)
+        true
+        (elapsed < 1.0))
+
 let tests = [
   test_case "pool create" `Quick (with_eio test_pool_create);
   test_case "acquire release" `Quick (with_eio test_pool_acquire_release);
@@ -98,4 +171,6 @@ let tests = [
   test_case "pool validate" `Quick (with_eio test_pool_validate);
   test_case "pool shutdown" `Quick (with_eio test_pool_shutdown);
   test_case "error to string" `Quick (with_eio test_pool_error_to_string);
+  test_case "acquire honours max_wait_time when connections hang" `Quick test_acquire_honours_max_wait_time_when_all_connections_hang;
+  test_case "acquire succeeds quickly when released" `Quick test_acquire_succeeds_quickly_when_connection_released;
 ]


### PR DESCRIPTION
## 요약

\`Pool.acquire\` (lib/pool.ml:257-273)이 \`Eio.Condition.await\`을 elapsed-time guard 안에서 호출. 두 결함:

### 1. Silent dead \`max_wait_time\` (Iter 68 shutdown drain과 동일 패턴)

\`Eio.Condition.await\`은 deadline 인자 없음 → \`release\` broadcast해야 깨어남. **모든 in-use connection이 hang** (slow downstream, deadlocked handler, dropped socket) → \`release\` 호출 안 됨 → broadcast 없음 → \`await\` 영원히 wait. \`elapsed > max_wait_time\` 체크는 *다음 broadcast 시*에만 evaluate → 영원히 hang.

**Blast radius**: pool은 모든 DB/HTTP call의 chokepoint. shutdown drain보다 application 전체에 더 큰 영향.

### 2. Lost-wakeup race

\`try_acquire → None\` 후 다른 fiber가 *await 진입 전*에 release+broadcast → broadcast 잃음 → connection idle한데 fiber는 *다음* broadcast까지 wait. \`max_wait_time\`가 보호하지 않는 hang.

## 변경

**\`lib/pool.ml\`** — \`acquire\` 재작성:

- \`Eio.Condition.await\` 폐기.
- 50ms 폴링 (\`Time_compat.sleep\`). 매 poll에서 \`try_acquire\` + elapsed check.
- \`waiting\` counter는 \`Fun.protect\`로 increment/decrement 보장 (timeout path에서도 정확).
- timeout 도달 시 \`total_timeouts\` stats 증가 + \`Pool_error Timeout\` raise.

폴링은 wasteful이지만 \`acquire\`은 *pool이 capacity에 도달했을 때만* 폴링 → 일반 case는 매우 적은 cycle.

**\`test/test_pool_suite.ml\`** — 2 신규 (Pool 그룹, 9 total):

- **\`acquire honours max_wait_time when connections hang\`** — 1-slot pool 점유 + 미release + \`max_wait_time:0.15\` + 두 번째 acquire 시도. \`Pool_error Timeout\` raise + elapsed ∈ [0.15s, 1.0s] + \`total_timeouts = 1\` 핀. PR 이전엔 *영원히 hang*했을 시나리오.
- **\`acquire succeeds quickly when released\`** — 50ms 후 fiber에서 release + \`max_wait_time:5.0\` + 두 번째 acquire → 1s 이내 성공 핀 (전체 timeout 안 기다림).

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **230 tests pass** in 0.49s (기존 228 + 신규 2).
- Pool 그룹 9/9 OK.
- 신규 회귀 테스트가 *기존 코드라면 무한 hang*하던 시나리오를 0.15s 안에 종료시킴 → silent dead config의 fix를 *직접 측정*.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 hang shape를 *차단*.
- ❌ string 분류기 아님.
- ❌ N-of-M 아님 — \`acquire\` 단일 함수 (release는 손 안 댐).
- ❌ catch-all/cap 안티패턴 아님 — \`max_wait_time\`은 user-configurable backpressure, suppression cap이 아님.

## RFC

\`RFC-WAIVED: connection pool 시멘틱 회복 (dead config 활성화). 외부 API contract 변경 없음 (\`max_wait_time\`이 *실제로* 상한이 되는 것뿐, backwards compatible).\`

## Related

Iter 68 PR #128 (\`Shutdown.wait_for_drain\`)과 동일 안티패턴의 두 번째 site. Silent dead config가 6번째 누적 (\`cluster\` fork-bomb, \`jobs\` retry_delay, \`backpressure\` Drop_newest, \`health\` is_ready, \`shutdown\` drain timeout, \`pool\` acquire deadline). Cycle audit candidate.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>