### PR TITLE
fix(backpressure): validate Window create/reserve invariants

### DIFF
--- a/lib/backpressure.ml
+++ b/lib/backpressure.ml
@@ -308,17 +308,64 @@ module Window = struct
     space_available : Eio.Condition.t;
   }
 
-  (** Create a window *)
-  let create ?(initial_size = 65536) ?(max_size = 1048576) () = {
-    size = initial_size;
-    max_size;
-    in_flight = 0;
-    mutex = Eio.Mutex.create ();
-    space_available = Eio.Condition.create ();
-  }
+  (** Create a window.
 
-  (** Reserve space in the window (blocks if full) *)
+      All sizes must be strictly positive, and [initial_size <=
+      max_size].  A zero or negative size makes [reserve]
+      permanently block (the wait loop's condition can never
+      become false through [release]), turning a misconfiguration
+      into a silent fiber leak. *)
+  let create ?(initial_size = 65536) ?(max_size = 1048576) () =
+    if max_size <= 0 then
+      invalid_arg
+        (Printf.sprintf
+           "Backpressure.Window.create: max_size must be > 0 (got %d)"
+           max_size);
+    if initial_size <= 0 then
+      invalid_arg
+        (Printf.sprintf
+           "Backpressure.Window.create: initial_size must be > 0 (got %d)"
+           initial_size);
+    if initial_size > max_size then
+      invalid_arg
+        (Printf.sprintf
+           "Backpressure.Window.create: initial_size (%d) > max_size (%d)"
+           initial_size max_size);
+    {
+      size = initial_size;
+      max_size;
+      in_flight = 0;
+      mutex = Eio.Mutex.create ();
+      space_available = Eio.Condition.create ();
+    }
+
+  (** Reserve space in the window (blocks if full).
+
+      Rejects two attacker-shaped (or buggy-caller) inputs that
+      would otherwise corrupt the window invariant:
+
+      - [amount <= 0]: the wait condition [in_flight + amount >
+        size] is trivially false for non-positive amounts, so the
+        loop falls through and [in_flight] gets decreased — the
+        next caller sees a negative [in_flight] and reserves
+        succeed against capacity that does not actually exist.
+      - [amount > max_size]: the wait condition can never become
+        false even with a full [release] + [update_size] (a
+        fresh window is at [max_size] and that is still less
+        than [amount]).  The fiber would block forever — a
+        silent deadlock distinct from a normal "wait for
+        capacity" wait because no caller action can unblock it. *)
   let reserve t amount =
+    if amount <= 0 then
+      invalid_arg
+        (Printf.sprintf
+           "Backpressure.Window.reserve: amount must be > 0 (got %d)"
+           amount);
+    if amount > t.max_size then
+      invalid_arg
+        (Printf.sprintf
+           "Backpressure.Window.reserve: amount %d exceeds max_size %d (would block forever)"
+           amount t.max_size);
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
       while t.in_flight + amount > t.size do
         Eio.Condition.await t.space_available t.mutex

--- a/test/test_backpressure_suite.ml
+++ b/test/test_backpressure_suite.ml
@@ -105,6 +105,73 @@ let test_window_update_size () =
   BP.Window.update_size win 1000;
   check int "capped at max" 500 (BP.Window.current_size win)
 
+(* Window validation regression tests.  Before this PR,
+   [Window.create] and [Window.reserve] accepted misconfigurations
+   that silently turned into permanent fiber hangs:
+
+   - [create ~initial_size:0] / [~max_size:0] / [initial > max]
+     left the wait loop unable to fall through
+   - [reserve ~amount:0] or negative — wait condition is trivially
+     false, falls through, [in_flight] decreased, invariant broken
+   - [reserve ~amount:N] with [N > max_size] — wait condition can
+     never become false even with full [release] / [update_size],
+     so the fiber hangs forever *)
+
+let test_window_create_rejects_zero_max () =
+  check_raises "max_size 0"
+    (Invalid_argument
+       "Backpressure.Window.create: max_size must be > 0 (got 0)")
+    (fun () -> ignore (BP.Window.create ~max_size:0 ()))
+
+let test_window_create_rejects_negative_max () =
+  check_raises "max_size -1"
+    (Invalid_argument
+       "Backpressure.Window.create: max_size must be > 0 (got -1)")
+    (fun () -> ignore (BP.Window.create ~max_size:(-1) ()))
+
+let test_window_create_rejects_zero_initial () =
+  check_raises "initial 0"
+    (Invalid_argument
+       "Backpressure.Window.create: initial_size must be > 0 (got 0)")
+    (fun () -> ignore (BP.Window.create ~initial_size:0 ()))
+
+let test_window_create_rejects_initial_above_max () =
+  check_raises "initial > max"
+    (Invalid_argument
+       "Backpressure.Window.create: initial_size (500) > max_size (100)")
+    (fun () -> ignore (BP.Window.create ~initial_size:500 ~max_size:100 ()))
+
+let test_window_reserve_rejects_nonpositive_amount () =
+  let win = BP.Window.create ~initial_size:100 ~max_size:1000 () in
+  check_raises "amount 0"
+    (Invalid_argument
+       "Backpressure.Window.reserve: amount must be > 0 (got 0)")
+    (fun () -> BP.Window.reserve win 0);
+  check_raises "amount -5"
+    (Invalid_argument
+       "Backpressure.Window.reserve: amount must be > 0 (got -5)")
+    (fun () -> BP.Window.reserve win (-5));
+  (* Invariant: in_flight stays at 0 — the rejected calls did not
+     corrupt the counter. *)
+  check int "in_flight unchanged" 0 (BP.Window.in_flight win)
+
+let test_window_reserve_rejects_amount_above_max () =
+  let win = BP.Window.create ~initial_size:100 ~max_size:200 () in
+  check_raises "amount > max_size"
+    (Invalid_argument
+       "Backpressure.Window.reserve: amount 300 exceeds max_size 200 (would block forever)")
+    (fun () -> BP.Window.reserve win 300);
+  check int "in_flight unchanged" 0 (BP.Window.in_flight win)
+
+let test_window_reserve_at_max_succeeds () =
+  (* Boundary: exactly [max_size] amount is allowed (it will
+     block until the window grows, but it is not an a-priori
+     deadlock).  Pin so a future "off-by-one tightening" cannot
+     regress the contract. *)
+  let win = BP.Window.create ~initial_size:200 ~max_size:200 () in
+  BP.Window.reserve win 200;
+  check int "in_flight at cap" 200 (BP.Window.in_flight win)
+
 let tests = [
   test_case "buffer create" `Quick (with_eio test_buffer_create);
   test_case "buffer push pop" `Quick (with_eio test_buffer_push_pop);
@@ -118,4 +185,11 @@ let tests = [
   test_case "window create" `Quick (with_eio test_window_create);
   test_case "window reserve release" `Quick (with_eio test_window_reserve_release);
   test_case "window update size" `Quick (with_eio test_window_update_size);
+  test_case "window create rejects zero max" `Quick (with_eio test_window_create_rejects_zero_max);
+  test_case "window create rejects negative max" `Quick (with_eio test_window_create_rejects_negative_max);
+  test_case "window create rejects zero initial" `Quick (with_eio test_window_create_rejects_zero_initial);
+  test_case "window create rejects initial above max" `Quick (with_eio test_window_create_rejects_initial_above_max);
+  test_case "window reserve rejects nonpositive amount" `Quick (with_eio test_window_reserve_rejects_nonpositive_amount);
+  test_case "window reserve rejects amount above max" `Quick (with_eio test_window_reserve_rejects_amount_above_max);
+  test_case "window reserve at exact max succeeds" `Quick (with_eio test_window_reserve_at_max_succeeds);
 ]


### PR DESCRIPTION
## 요약

\`Backpressure.Window\`의 \`create\`/\`reserve\`에 invariant validation 부재. 4 silent deadlock 시나리오:

1. \`create ~max_size:0\` (또는 음수) — \`reserve\` wait 조건이 영원히 true.
2. \`create ~initial_size:0\` — \`reserve\` wait이 \`update_size\` 호출까지 hang.
3. \`create ~initial_size:N ~max_size:M\` (N > M) — invariant 위반 시작 상태.
4. \`reserve ~amount:N\` (N > max_size) — wait 조건이 release+update_size 둘 다 호출되어도 false 못 됨. **silent permanent hang**, 일반 \"wait for capacity\"와 구분 안 됨.
5. \`reserve ~amount:0\` 또는 음수 — wait trivially false → loop 통과 → \`in_flight\` 감소 → 다른 reserve가 가짜 capacity로 통과 → invariant 깨짐.

이전 audit (Iter 69 인사이트) — \`Eio.Condition.await\` callsite sweep에서 \`Window.reserve\`만 untouched silent-deadlock surface로 남아있음.

## 변경

**\`lib/backpressure.ml\`** — \`Window\` 모듈 validation 추가:

- \`create\`: \`max_size > 0\`, \`initial_size > 0\`, \`initial_size <= max_size\` 강제. 위반 시 \`Invalid_argument\` + 정확한 진단.
- \`reserve\`: \`amount > 0\` && \`amount <= max_size\` 강제. \`amount = max_size\` (boundary)는 허용 (legitimate \"fill the whole window\" 패턴, a-priori deadlock 아님).
- 같은 shape: PR #123 (Iter 63) \`Buffer.create ~capacity\` validation의 \`Window\` 일반화.

**\`test/test_backpressure_suite.ml\`** — 7 신규 (Backpressure 그룹, 19 total):

- \`create\` reject 4 종 (zero max / negative max / zero initial / initial > max).
- \`reserve\` reject 2 종 (nonpositive amount / amount > max_size) + \`in_flight\` 회귀 invariant (rejected call이 counter 손상 안 시킴).
- \`reserve at exact max\` succeeds — boundary 핀 (off-by-one tightening 회귀 차단).

## 검증

- \`dune exec --root . test/test_kirin.exe\` — **235 tests pass** in 0.25s (기존 228 + 신규 7).
- Backpressure 그룹 19/19 OK.

## 워크어라운드 거부 기준 self-check

- ❌ 텔레메트리-as-fix 아님 — 실제 silent deadlock surface를 *닫음*.
- ❌ string 분류기 아님 — typed integer invariant.
- ❌ N-of-M 아님 — \`create\`/\`reserve\` 두 진입점 + 4 silent shape 같은 PR에서.
- ❌ catch-all/cap 안티패턴 아님 — fail-loud invariant 강제.

## RFC

\`RFC-WAIVED: data plane silent deadlock fix. 외부 API contract는 \`reserve\`/\`create\`이 invalid input에 raise 추가 (이전엔 silent hang). 정상 입력 영향 없음 (backwards compatible).\`

## Related — \`Eio.Condition.await\` audit sweep 완료

- PR #128 (Iter 68) — \`Shutdown.wait_for_drain\` deadline fix.
- PR #129 (Iter 69) — \`Pool.acquire\` deadline fix.
- 이 PR (Iter 70) — \`Window.reserve\` invariant fix.
- \`Jobs.wait\` / \`Buffer.push|pop\` Block strategy / \`PubSub.wait\` — *intentional* infinite wait (by design). 결함 아님.

audit 결과 silent dead-condition pattern은 이번 PR로 마무리. 누적 8건 silent-dead-default fix (Iter 57/59/61/63/65/68/69/70).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>